### PR TITLE
Cache generated txamqp specs.

### DIFF
--- a/vumi/service.py
+++ b/vumi/service.py
@@ -19,6 +19,22 @@ from vumi.webapp.api import utils
 from vumi.utils import load_class_by_string, make_vumi_path_abs
 
 
+SPECS = {}
+
+
+def get_spec(specfile):
+    """
+    Cache the generated part of txamqp, because generating it is expensive.
+
+    This is important for tests, which create lots of txamqp clients,
+    and therefore generate lots of specs. Just doing this results in a
+    decidedly happy test run time reduction.
+    """
+    if specfile not in SPECS:
+        SPECS[specfile] = txamqp.spec.load(specfile)
+    return SPECS[specfile]
+
+
 class Options(usage.Options):
     """
     Default options for all workers created
@@ -47,7 +63,7 @@ class AmqpFactory(protocol.ReconnectingClientFactory):
     def __init__(self, worker_class, options, config):
         self.options = options
         self.config = config
-        self.spec = txamqp.spec.load(make_vumi_path_abs(options['specfile']))
+        self.spec = get_spec(make_vumi_path_abs(options['specfile']))
         self.delegate = TwistedDelegate()
         self.worker_class = worker_class
 

--- a/vumi/tests/test_fake_amqp.py
+++ b/vumi/tests/test_fake_amqp.py
@@ -1,8 +1,7 @@
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks, Deferred
-import txamqp.spec
 
-from vumi.service import Worker
+from vumi.service import get_spec, Worker
 from vumi.utils import make_vumi_path_abs
 from vumi.tests import fake_amqp
 
@@ -168,7 +167,7 @@ class FakeAMQPTestCase(TestCase):
 
     @inlineCallbacks
     def test_fake_amqclient(self):
-        spec = txamqp.spec.load(make_vumi_path_abs("config/amqp-spec-0-8.xml"))
+        spec = get_spec(make_vumi_path_abs("config/amqp-spec-0-8.xml"))
         amq_client = fake_amqp.FakeAMQClient(spec, {}, self.broker)
         d = Deferred()
 

--- a/vumi/tests/utils.py
+++ b/vumi/tests/utils.py
@@ -8,11 +8,10 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 import pytz
-import txamqp
 from twisted.internet import defer
 
 from vumi.utils import make_vumi_path_abs
-from vumi.service import Worker
+from vumi.service import get_spec, Worker
 from vumi.tests.fake_amqp import FakeAMQClient
 
 
@@ -180,14 +179,14 @@ class TestChannel(object):
 
 
 def get_stubbed_worker(worker_class, config=None, broker=None):
-    spec = txamqp.spec.load(make_vumi_path_abs("config/amqp-spec-0-8.xml"))
+    spec = get_spec(make_vumi_path_abs("config/amqp-spec-0-8.xml"))
     amq_client = FakeAMQClient(spec, {}, broker)
     worker = worker_class(amq_client, config)
     return worker
 
 
 def get_stubbed_channel(broker=None, id=0):
-    spec = txamqp.spec.load(make_vumi_path_abs("config/amqp-spec-0-8.xml"))
+    spec = get_spec(make_vumi_path_abs("config/amqp-spec-0-8.xml"))
     amq_client = FakeAMQClient(spec, {}, broker)
     return amq_client.channel(id)
 


### PR DESCRIPTION
I was originally going to have more than just this in the branch, but there aren't any obvious other speedups to be made, beyond ripping out the Django ORM.

Here are some before and after numbers for running the tests on my machine:

vumi:
Before: Ran 157 tests in 51.368s
After: Ran 157 tests in 31.795s

vumi-campaigns:
Before: Ran 88 tests in 41.561s
After: Ran 88 tests in 18.802s 
