### PR TITLE
Remove spurious @inlineCallbacks, which gets rid of horrible stack trace 

### DIFF
--- a/vumi/transports/smpp/transport.py
+++ b/vumi/transports/smpp/transport.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 import redis
 from twisted.python import log
-from twisted.internet.defer import inlineCallbacks
 from twisted.internet import reactor
 
 # from vumi.service import Worker
@@ -75,7 +74,6 @@ class SmppTransport(Transport):
         self.r_set_id_for_sequence(sequence_number,
                                    message.payload.get("message_id"))
 
-    @inlineCallbacks
     def esme_disconnected(self):
         log.msg("ESME Disconnected")
 


### PR DESCRIPTION
Remove spurious @inlineCallbacks, which gets rid of horrible stack trace when stopping SMPP.
