### PR TITLE
Split development dependencies out in config/requirements-dev.pip.

### DIFF
--- a/config/requirements-dev.pip
+++ b/config/requirements-dev.pip
@@ -1,0 +1,7 @@
+Sphinx==1.0.7
+nose==0.11.3
+django-nose
+coverage
+python-subunit
+junitxml
+pep8

--- a/config/requirements.pip
+++ b/config/requirements.pip
@@ -5,7 +5,6 @@ twisted==10.1
 txamqp==0.5
 Django==1.3
 importlib==1.0.2
-nose==0.11.3
 PyYAML==3.09
 pycurl==7.18.1
 decorator
@@ -15,9 +14,6 @@ iso8601==0.1.4
 supervisor
 psycopg2==2.4.1
 South==0.7.3
-Sphinx==1.0.7
-django-nose
-coverage
 pyOpenSSL==0.11
 python-ssmi
 python-foneworx
@@ -33,7 +29,3 @@ python-fusiontables==0.1
 # oauth and simplejson are needed by twittytwister
 oauth
 simplejson
-# for Jenkins
-python-subunit
-junitxml
-pep8


### PR DESCRIPTION
Thoughts?

We'll have to update Jenkin's build steps to install requirements-dev.pip if this lands.
