### PR TITLE
using unique id in XMPP transport over message['id']

### DIFF
--- a/vumi/transports/xmpp/tests/test_xmpp.py
+++ b/vumi/transports/xmpp/tests/test_xmpp.py
@@ -64,5 +64,6 @@ class XMPPTransportTestCase(TransportTestCase):
         self.assertEqual(msg['to_addr'], self.jid.userhost())
         self.assertEqual(msg['from_addr'], 'test@case.com')
         self.assertEqual(msg['transport_name'], 'test_xmpp')
-        self.assertEqual(msg['message_id'], message['id'])
+        self.assertNotEqual(msg['message_id'], message['id'])
+        self.assertEqual(msg['transport_metadata']['xmpp_id'], message['id'])
         self.assertEqual(msg['content'], 'hello world')

--- a/vumi/transports/xmpp/xmpp.py
+++ b/vumi/transports/xmpp/xmpp.py
@@ -69,7 +69,9 @@ class XMPPTransportProtocol(MessageProtocol, object):
             from_addr=message['from'],
             content=text,
             transport_type='xmpp',
-            message_id=message['id'])
+            transport_metadata={
+                'xmpp_id': message.getAttribute('id'),
+            })
 
     def connectionMade(self):
         self.connection_callback()


### PR DESCRIPTION
small fix (#141)
