### PR TITLE
Feature/issue 154 evict redis from tests

### DIFF
--- a/vumi/transports/opera/opera.py
+++ b/vumi/transports/opera/opera.py
@@ -141,8 +141,7 @@ class OperaTransport(Transport):
 
         dbindex = get_deploy_int(self._amqp_client.vhost)
         redis_config = self.config.get('redis', {})
-        if not hasattr(self, 'r_server'):
-            self.r_server = yield redis.Redis(db=dbindex, **redis_config)
+        self.r_server = yield redis.Redis(db=dbindex, **redis_config)
         self.r_prefix = "%(transport_name)s@%(url)s" % self.config
 
         self.proxy = xmlrpc.Proxy(self.opera_url)

--- a/vumi/transports/opera/tests/test_opera.py
+++ b/vumi/transports/opera/tests/test_opera.py
@@ -43,9 +43,8 @@ class OperaTransportTestCase(TransportTestCase):
         }
         default_config.update(config)
         self.r_server = FakeRedis()
-        worker = yield self.get_transport(default_config, cls, start=False)
+        worker = yield self.get_transport(default_config, cls)
         worker.r_server = self.r_server
-        yield worker.startWorker()
         returnValue(worker)
 
     def mk_msg(self, **kwargs):


### PR DESCRIPTION
This fixes two of the four cases of real redis being used instead of FakeRedis.

The two remaining are in the SMPP transport (which is being hacked on in another branch) and the bowels of `vumi.workers.SessionWorker` which needs to go away just as soon as we have better tests around the session stuff.
(#154)
