### PR TITLE
Add sunion and smove to FakeRedis

### DIFF
--- a/vumi/tests/test_testutils.py
+++ b/vumi/tests/test_testutils.py
@@ -88,3 +88,25 @@ class FakeRedisTestCase(TestCase):
         self.r_server.sadd('set', 2, 3, 4)
         self.assertEqual(self.r_server.smembers('set'), set([
             '1', '2', '3', '4']))
+
+    def test_smove(self):
+        self.r_server = FakeRedis()
+        self.r_server.sadd('set1', 1)
+        self.r_server.sadd('set2', 2)
+        self.assertEqual(self.r_server.smove('set1', 'set2', '1'), True)
+        self.assertEqual(self.r_server.smembers('set1'), set())
+        self.assertEqual(self.r_server.smembers('set2'), set(['1', '2']))
+
+        self.assertEqual(self.r_server.smove('set1', 'set2', '1'), False)
+
+        self.assertEqual(self.r_server.smove('set2', 'set3', '1'), True)
+        self.assertEqual(self.r_server.smembers('set2'), set(['2']))
+        self.assertEqual(self.r_server.smembers('set3'), set(['1']))
+
+    def test_sunion(self):
+        self.r_server = FakeRedis()
+        self.r_server.sadd('set1', 1)
+        self.r_server.sadd('set2', 2)
+        self.assertEqual(self.r_server.sunion('set1'), set(['1']))
+        self.assertEqual(self.r_server.sunion('set1', 'set2'), set(['1', '2']))
+        self.assertEqual(self.r_server.sunion('other'), set())

--- a/vumi/tests/utils.py
+++ b/vumi/tests/utils.py
@@ -361,6 +361,18 @@ class FakeRedis(object):
     def scard(self, key):
         return len(self._data.get(key, set()))
 
+    def smove(self, src, dst, value):
+        result = self.srem(src, value)
+        if result:
+            self.sadd(dst, value)
+        return result
+
+    def sunion(self, key, *args):
+        union = set()
+        for rkey in (key,) + args:
+            union.update(self._data.get(rkey, set()))
+        return union
+
     # Sorted set operations
 
     def zadd(self, key, **valscores):


### PR DESCRIPTION
FakeRedis is missing sunion and smove and they're needed for Vumi Go's tag pool.
