### PR TITLE
IRC transport should notice NOTICEs

### DIFF
--- a/vumi/transports/irc/irc.py
+++ b/vumi/transports/irc/irc.py
@@ -116,6 +116,12 @@ class VumiBotProtocol(irc.IRCClient):
                              self.nickname)
         self.publish_message(irc_msg)
 
+    def noticed(self, sender, recipient, message):
+        """This will get called when the bot receives a notice."""
+        irc_msg = IrcMessage(sender, 'NOTICE', recipient, message,
+                             self.nickname)
+        self.publish_message(irc_msg)
+
     def action(self, sender, recipient, message):
         """This will get called when the bot sees someone do an action."""
         irc_msg = IrcMessage(sender, 'ACTION', recipient, message,

--- a/vumi/transports/irc/tests/test_irc.py
+++ b/vumi/transports/irc/tests/test_irc.py
@@ -256,6 +256,28 @@ class TestIrcTransport(TransportTestCase):
             })
 
     @inlineCallbacks
+    def test_handle_inbound_notice(self):
+        sender, recipient, text = "user!ident@host", "#zoo", "Hello gooites"
+        self.irc_server.client.notice(sender, recipient, text)
+        [msg] = yield self.wait_for_dispatched_messages(1)
+        self.assertEqual(msg['transport_name'], self.transport_name)
+        self.assertEqual(msg['to_addr'], "#zoo")
+        self.assertEqual(msg['from_addr'], "user")
+        self.assertEqual(msg['content'], text)
+        self.assertEqual(msg['helper_metadata'], {
+            'irc': {
+                'transport_nickname': self.nick,
+                'addressed_to_transport': False,
+                'irc_server': self.server_addr,
+                'irc_channel': '#zoo',
+                'irc_command': 'NOTICE',
+                }
+            })
+        self.assertEqual(msg['transport_metadata'], {
+            'irc_channel': '#zoo',
+            })
+
+    @inlineCallbacks
     def test_handle_outbound_message_while_disconnected(self):
         yield self.irc_connector.stopListening()
         self.transport.client.disconnect()


### PR DESCRIPTION
The IRC transport currently treats `NOTICE`s as `PRIVMSGS`s. They should have a different `irc_command` field, so bot workers can recognise them and ignore them. (To prevent bots triggering other bots, for example.)
