### PR TITLE
from_addr-based dispatcher router

### DIFF
--- a/vumi/dispatchers/base.py
+++ b/vumi/dispatchers/base.py
@@ -226,7 +226,7 @@ class FromAddrMultiplexRouter(BaseDispatchRouter):
 
     def dispatch_inbound_event(self, msg):
         self._handle_inbound(
-            msg, self.dispatcher.exposed_event_publisher[self.exposed])
+            msg, self.dispatcher.exposed_event_publisher[self.exposed_name])
 
     def dispatch_outbound_message(self, msg):
         name = self.config['fromaddr_mappings'][msg['from_addr']]


### PR DESCRIPTION
If we have a pool of transports to handle a range of addresses (such as `XMPPTransport`, which only handles one address per instance), it would be convenient to hide them behind a dispatcher that exposes itself as a single transport that can handle multiple addresses.

For example, we could have transports `vumitest_xmpp_1` with address `vumitest1@mydomain.com` through `vumitest_xmpp_5` with address `vumitest5@mydomain.com` behind a single `vumitest_xmpp` dispatcher which rewrites the `transport_name` in both directions and routes outbound messages according to `from_addr`.
