### PR TITLE
Incorrect handling of IRC ACTION outbound messages

### DIFF
--- a/vumi/transports/irc/irc.py
+++ b/vumi/transports/irc/irc.py
@@ -259,7 +259,7 @@ class IrcTransport(Transport):
         recipient = irc_channel if irc_channel is not None else msg['to_addr']
         content = msg['content']
 
-        if irc_channel and msg['to_addr']:
+        if irc_channel and msg['to_addr'] and (irc_command != 'ACTION'):
             # We have a directed channel message, so prefix with the nick.
             content = "%s: %s" % (msg['to_addr'], content)
 

--- a/vumi/transports/tests/test_base.py
+++ b/vumi/transports/tests/test_base.py
@@ -124,11 +124,13 @@ class TransportTestCase(unittest.TestCase):
                   session_event=TransportUserMessage.SESSION_NONE,
                   message_id='1', to_addr='+41791234567', from_addr='9292',
                   group=None, in_reply_to=None, transport_type=None,
-                  transport_metadata=None):
+                  transport_metadata=None, helper_metadata=None):
         if transport_type is None:
             transport_type = self.transport_type
         if transport_metadata is None:
             transport_metadata = {}
+        if helper_metadata is None:
+            helper_metadata = {}
         params = dict(
             to_addr=to_addr,
             from_addr=from_addr,
@@ -140,6 +142,7 @@ class TransportTestCase(unittest.TestCase):
             content=content,
             session_event=session_event,
             in_reply_to=in_reply_to,
+            helper_metadata=helper_metadata,
             )
         return TransportUserMessage(**params)
 


### PR DESCRIPTION
The IRC transport adds a nick prefix to outbound group-directed ACTION messages. This should be avoided.
