### PR TITLE
FakeRedis hgetall returns a reference to internal dictionaries

### DIFF
--- a/vumi/tests/test_testutils.py
+++ b/vumi/tests/test_testutils.py
@@ -69,6 +69,15 @@ class FakeRedisTestCase(TestCase):
         self.assertEqual(self.r_server.zrange('set', 0, -1, desc=True,
             withscores=True), [(0.3, 'three'), (0.2, 'two'), (0.1, 'one')])
 
+    def test_hgetall_returns_copy(self):
+        self.r_server = FakeRedis()
+        self.r_server.hset("hash", "foo", "1")
+        data = self.r_server.hgetall("hash")
+        data["foo"] = "2"
+        self.assertEqual(self.r_server.hgetall("hash"), {
+            "foo": "1",
+            })
+
     def test_hincrby(self):
         self.r_server = FakeRedis()
         hincrby = self.r_server.hincrby

--- a/vumi/tests/utils.py
+++ b/vumi/tests/utils.py
@@ -321,7 +321,7 @@ class FakeRedis(object):
             for key, value in mapping.items()]))
 
     def hgetall(self, key):
-        return self._data.get(key, {})
+        return self._data.get(key, {}).copy()
 
     def hlen(self, key):
         return len(self._data.get(key, {}))


### PR DESCRIPTION
The FakeRedis hgetall function returns a reference to an internal data dictionaries instead of a copy. This means that if the returned dictionary is modified, the values in FakeRedis are modified too.
