### PR TITLE
Ashish/Asif - http api can now take the transport_name from the request ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage.xml
 test_results.xml
 django_test_results.xml
 /pep8.txt
+.idea

--- a/vumi/transports/api/api.py
+++ b/vumi/transports/api/api.py
@@ -45,7 +45,7 @@ class HttpApiTransport(HttpRpcTransport):
     def setup_transport(self):
         self.reply_expected = self.config.get('reply_expected', False)
         self.allowed_fields = self.config.get('allowed_fields',
-                                              self.DEFAULT_ALLOWED_FIELDS)
+            self.DEFAULT_ALLOWED_FIELDS)
         self.field_defaults = self.config.get('field_defaults', {})
         return super(HttpApiTransport, self).setup_transport()
 
@@ -72,8 +72,14 @@ class HttpApiTransport(HttpRpcTransport):
 
     @inlineCallbacks
     def handle_raw_inbound_message(self, message_id, request):
-        values, errors = self.get_field_values(
-            request, 'content', 'to_addr', 'from_addr')
+        if self.allowed_fields.count('transport_name') is 0:
+            values, errors = self.get_field_values(request, 'content', 'to_addr', 'from_addr')
+        else:
+            values, errors = self.get_field_values(
+                request, 'content', 'to_addr', 'from_addr' ,'transport_name')
+            transport_name = values.get('transport_name', None)
+            if transport_name is not None:
+                self.transport_name=transport_name
         if errors:
             yield self.finish_request(message_id, json.dumps(errors), code=400)
             return
@@ -89,4 +95,4 @@ class HttpApiTransport(HttpRpcTransport):
         )
         if not self.reply_expected:
             yield self.finish_request(message_id,
-                                      json.dumps({'message_id': message_id}))
+                json.dumps({'message_id': message_id}))

--- a/vumi/transports/api/tests/test_api.py
+++ b/vumi/transports/api/tests/test_api.py
@@ -145,3 +145,11 @@ class TestHttpApiTransport(TransportTestCase):
         self.assertEqual(400, response.code)
         self.assertEqual(json.loads(response.delivered_body),
                          {'unexpected_parameter': ['to_addr']})
+
+    @inlineCallbacks
+    @config_override(allowed_fields=['content', 'from_addr', 'to_addr', 'transport_name'])
+    def test_transport_name_in_input(self):
+        url = self.mkurl('hello' ,transport_name='smpp_transport')
+        response = yield http_request_full(url, '', method='GET')
+        self.assertEqual(200, response.code)
+        self.assertEqual(self.transport.transport_name, 'smpp_transport')


### PR DESCRIPTION
...as long as transport_name has been configured as an allowed field
