### PR TITLE
Bump required version of Twisted and relax other dependencies.

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,9 +1,11 @@
 zope.interface
-Twisted==10.1
-txAMQP==0.5
-PyYAML==3.09
-iso8601==0.1.4
+Twisted
+# txAMQP prior to 0.5 does not support modern rabbitMQ versions.
+txAMQP>=0.5
+PyYAML
+iso8601
 supervisor
+# Newer pyOpenSSL fails to build on MacOS X 10.6.
 pyOpenSSL==0.11
 python-ssmi
 wokkel


### PR DESCRIPTION
The version of Twisted required in vumi's requirements.pip is currently 10.1. This doesn't compile cleanly on OS X Lion. Twisted 12.0 does. We should consider upgrading the required version of Twisted.

Note: We expanded this ticket to include relaxing the version requirements on other dependencies.
