### PR TITLE
HTTP API transport should support additional message parameters

### DIFF
--- a/vumi/transports/api/tests/test_api.py
+++ b/vumi/transports/api/tests/test_api.py
@@ -95,6 +95,15 @@ class TestHttpApiTransport(TransportTestCase):
         self.assertEqual(response, 'OK')
 
     @inlineCallbacks
+    def test_good_optional_parameter(self):
+        url = self.mkurl('hello', group='#channel')
+        response = yield http_request(url, '', method='GET')
+        [msg] = self.get_dispatched_messages()
+        self.assertEqual(msg['group'], '#channel')
+        self.assertEqual(json.loads(response),
+                         {'message_id': msg['message_id']})
+
+    @inlineCallbacks
     def test_bad_parameter(self):
         url = self.mkurl('hello', foo='bar')
         response = yield http_request_full(url, '', method='GET')


### PR DESCRIPTION
The current HTTP API supports allowing additional message parameters to be passed in but doesn't actually add them to the message payload (because historically the support that exists was intended to allow further _restricting_ the set of parameters passed in).

The 'group' attribute also needs to be added to the default set of allowed attributes (this was added to the core vumi message after the HTTP API was written).
