### PR TITLE
Various HTTP transports log health checks noisily

### DIFF
--- a/vumi/service.py
+++ b/vumi/service.py
@@ -8,7 +8,6 @@ from twisted.application.service import MultiService
 from twisted.application.internet import TCPClient
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet import protocol, reactor
-from twisted.web.server import Site
 from twisted.web.resource import Resource
 import txamqp
 from txamqp.client import TwistedDelegate
@@ -18,7 +17,7 @@ from txamqp.protocol import AMQClient
 from vumi.errors import VumiError
 from vumi.message import Message
 from vumi.utils import (load_class_by_string, vumi_resource_path, http_request,
-                        basic_auth_string)
+                        basic_auth_string, LogFilterSite)
 
 
 SPECS = {}
@@ -265,7 +264,7 @@ class Worker(MultiService, object):
             parent.putChild(leaf, resource)
 
         if site_class is None:
-            site_class = Site
+            site_class = LogFilterSite
         site_factory = site_class(root)
         return reactor.listenTCP(port, site_factory)
 

--- a/vumi/transports/httprpc/httprpc.py
+++ b/vumi/transports/httprpc/httprpc.py
@@ -20,6 +20,7 @@ class HttpRpcHealthResource(Resource):
 
     def render_GET(self, request):
         request.setResponseCode(http.OK)
+        request.do_not_log = True
         return self.transport.get_health_response()
 
 

--- a/vumi/transports/integrat/integrat.py
+++ b/vumi/transports/integrat/integrat.py
@@ -82,6 +82,7 @@ class HealthResource(Resource):
 
     def render(self, request):
         request.setResponseCode(http.OK)
+        request.do_not_log = True
         return 'OK'
 
 

--- a/vumi/transports/opera/opera.py
+++ b/vumi/transports/opera/opera.py
@@ -28,6 +28,7 @@ class OperaHealthResource(Resource):
 
     def render_GET(self, request):
         request.setResponseCode(http.OK)
+        request.do_not_log = True
         return "OK"
 
 

--- a/vumi/transports/vas2nets/vas2nets.py
+++ b/vumi/transports/vas2nets/vas2nets.py
@@ -9,13 +9,13 @@ from StringIO import StringIO
 
 from twisted.web import http
 from twisted.web.resource import Resource
-from twisted.web.server import Site, NOT_DONE_YET
+from twisted.web.server import NOT_DONE_YET
 from twisted.python import log
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.protocol import Protocol
 from twisted.internet.error import ConnectionRefusedError
 
-from vumi.utils import http_request_full, normalize_msisdn
+from vumi.utils import http_request_full, normalize_msisdn, LogFilterSite
 from vumi.transports.base import Transport
 from vumi.transports.failures import TemporaryFailure, PermanentFailure
 from vumi.errors import VumiError
@@ -197,13 +197,6 @@ class HttpResponseHandler(Protocol):
 
     def connectionLost(self, reason):
         self.deferred.callback(self.stringio.getvalue())
-
-
-class LogFilterSite(Site):
-    def log(self, request):
-        if getattr(request, 'do_not_log', None):
-            return
-        return Site.log(self, request)
 
 
 class Vas2NetsTransport(Transport):

--- a/vumi/utils.py
+++ b/vumi/utils.py
@@ -11,6 +11,7 @@ from twisted.internet import defer
 from twisted.internet import reactor, protocol
 from twisted.internet.defer import succeed
 from twisted.web.client import Agent, ResponseDone
+from twisted.web.server import Site
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 from twisted.web.http import PotentialDataLoss
@@ -138,6 +139,13 @@ class StringProducer(object):
 
     def stopProducing(self):
         pass
+
+
+class LogFilterSite(Site):
+    def log(self, request):
+        if getattr(request, 'do_not_log', None):
+            return
+        return Site.log(self, request)
 
 
 def vumi_resource_path(path):


### PR DESCRIPTION
Several HTTP transports log health checks from load balancers. This fills up the logs with noise, and is generally useless.

The vas2nets transport suppresses this logging, and I'd like to do the same in other HTTP transports.
