### PR TITLE
Add .delete() to vumi.persist.model.Model instances.

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -115,9 +115,19 @@ class Model(object):
         """Save the object to Riak.
 
         :returns:
-            A deferred that fires once the data is saved.
+            A deferred that fires once the data is saved (or None if
+            using a synchronous manager).
         """
         return self.manager.store(self)
+
+    def delete(self):
+        """Delete the object from Riak.
+
+        :returns:
+            A deferred that fires once the data is deleted (or None if
+            using a synchronous manager).
+        """
+        return self.manager.delete(self)
 
     @classmethod
     def load(cls, manager, key):
@@ -204,6 +214,11 @@ class Manager(object):
         """Store the modelobj in Riak."""
         raise NotImplementedError("Sub-classes of Manager should implement"
                                   " .store(...)")
+
+    def delete(self, modelobj):
+        """Delete the modelobj from Riak."""
+        raise NotImplementedError("Sub-classes of Manager should implement"
+                                  " .delete(...)")
 
     def load(self, cls, key):
         """Load a model instance for the key from Riak.

--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -59,6 +59,9 @@ class RiakManager(Manager):
         modelobj._riak_object.store()
         return modelobj
 
+    def delete(self, modelobj):
+        modelobj._riak_object.delete()
+
     def load(self, cls, key):
         riak_object = self.riak_object(cls, key)
         riak_object.reload()

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -130,6 +130,18 @@ class TestModelOnTxRiak(TestCase):
         self.assertEqual(s2.b, u'3')
 
     @Manager.calls_manager
+    def test_simple_instance_delete(self):
+        simple_model = self.manager.proxy(SimpleModel)
+        s1 = simple_model("foo", a=5, b=u'3')
+        yield s1.save()
+
+        s2 = yield simple_model.load("foo")
+        yield s2.delete()
+
+        s3 = yield simple_model.load("foo")
+        self.assertEqual(s3, None)
+
+    @Manager.calls_manager
     def test_nonexist_keys_return_none(self):
         simple_model = self.manager.proxy(SimpleModel)
         s = yield simple_model.load("foo")

--- a/vumi/persist/tests/test_txriak_manager.py
+++ b/vumi/persist/tests/test_txriak_manager.py
@@ -72,6 +72,17 @@ class CommonRiakManagerTests(object):
         self.assertEqual(dummy2.get_data(), {"a": 1})
 
     @Manager.calls_manager
+    def test_delete(self):
+        dummy1 = self.mkdummy("foo", {"a": 1})
+        yield self.manager.store(dummy1)
+
+        dummy2 = yield self.manager.load(DummyModel, "foo")
+        yield self.manager.delete(dummy2)
+
+        dummy3 = yield self.manager.load(DummyModel, "foo")
+        self.assertEqual(dummy3, None)
+
+    @Manager.calls_manager
     def test_load_missing(self):
         dummy = self.mkdummy("unknown")
         result = yield self.manager.load(DummyModel, dummy.key)

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -33,6 +33,9 @@ class TxRiakManager(Manager):
         d.addCallback(lambda result: modelobj)
         return d
 
+    def delete(self, modelobj):
+        return modelobj._riak_object.delete()
+
     def load(self, cls, key):
         riak_object = self.riak_object(cls, key)
         d = riak_object.reload()


### PR DESCRIPTION
Currently there isn't a way to delete a Model instance from Riak. Doh. :)
