### PR TITLE
Stringify **kwargs passed to Message.__init__().

### DIFF
--- a/vumi/message.py
+++ b/vumi/message.py
@@ -6,6 +6,9 @@ from datetime import datetime
 
 from errors import MissingMessageField, InvalidMessageField
 
+from vumi.utils import to_kwargs
+
+
 # This is the date format we work with internally
 VUMI_DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
@@ -75,9 +78,7 @@ class Message(object):
 
     @classmethod
     def from_json(cls, json_string):
-        msg_dict = dict((k.encode('utf8'), v)
-                        for k, v in from_json(json_string).iteritems())
-        return cls(_process_fields=False, **msg_dict)
+        return cls(_process_fields=False, **to_kwargs(from_json(json_string)))
 
     def __str__(self):
         return u"<Message payload=\"%s\">" % repr(self.payload)

--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 
 from vumi.message import VUMI_DATE_FORMAT
+from vumi.utils import to_kwargs
 
 
 class ValidationError(Exception):
@@ -241,7 +242,9 @@ class VumiMessageDescriptor(FieldDescriptor):
                 if key == "timestamp":
                     value = self._timestamp_from_json(value)
                 payload[key] = value
-        return self.field.message_class(**payload) if payload else None
+        if not payload:
+            return None
+        return self.field.message_class(**to_kwargs(payload))
 
 
 class VumiMessage(Field):

--- a/vumi/scripts/inject_messages.py
+++ b/vumi/scripts/inject_messages.py
@@ -8,6 +8,7 @@ from twisted.internet.defer import (maybeDeferred, DeferredQueue,
 from vumi.message import TransportUserMessage
 from vumi.service import Worker, WorkerCreator
 from vumi.servicemaker import VumiOptions
+from vumi.utils import to_kwargs
 
 
 class InjectorOptions(VumiOptions):
@@ -57,7 +58,7 @@ class MessageInjector(Worker):
         }
         data.update(json.loads(line))
         self.publisher.publish_message(
-            TransportUserMessage(**data))
+            TransportUserMessage(**to_kwargs(data)))
 
 
 @inlineCallbacks

--- a/vumi/transports/tests/test_scheduler.py
+++ b/vumi/transports/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from twisted.trial.unittest import TestCase
 from vumi.tests.utils import FakeRedis
 from vumi.transports.scheduler import Scheduler
 from vumi.message import TransportUserMessage
+from vumi.utils import to_kwargs
 
 
 class SchedulerTestCase(TestCase):
@@ -25,7 +26,7 @@ class SchedulerTestCase(TestCase):
         return (scheduled_at, message)
 
     def assertDelivered(self, message):
-        delivered_messages = [TransportUserMessage(**payload)
+        delivered_messages = [TransportUserMessage(**to_kwargs(payload))
                                 for _, payload in self._delivery_history]
         self.assertIn(message['message_id'],
             [message['message_id'] for message in delivered_messages])

--- a/vumi/utils.py
+++ b/vumi/utils.py
@@ -32,6 +32,15 @@ def import_module(name):
     return sys.modules[name]
 
 
+def to_kwargs(kwargs):
+    """
+    Convert top-level keys from unicode to string for older Python versions.
+
+    See http://bugs.python.org/issue2646 for details.
+    """
+    return dict((k.encode('utf8'), v) for k, v in kwargs.iteritems())
+
+
 class SimplishReceiver(protocol.Protocol):
     def __init__(self, response):
         self.deferred = defer.Deferred()


### PR DESCRIPTION
This is for older Python 2.6 which shuns unicode keywords.
