### PR TITLE
Add JSON blob field type to vumi.persist.

### DIFF
--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -199,6 +199,11 @@ class Timestamp(Field):
         return datetime.strptime(value, VUMI_DATE_FORMAT)
 
 
+class Json(Field):
+    """Field that stores an object that can be serialized to/from JSON."""
+    pass
+
+
 class VumiMessageDescriptor(FieldDescriptor):
     """Property for getting and setting fields."""
 

--- a/vumi/persist/tests/test_fields.py
+++ b/vumi/persist/tests/test_fields.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from twisted.trial.unittest import TestCase
 
 from vumi.persist.fields import (
-    ValidationError, Field, Integer, Unicode, Tag, Timestamp,
+    ValidationError, Field, Integer, Unicode, Tag, Timestamp, Json,
     Dynamic, FieldWithSubtype)
 
 
@@ -111,6 +111,23 @@ class TestTimestamp(TestCase):
         t = Timestamp()
         dt = datetime(2100, 10, 5, 11, 10, 9)
         self.assertEqual(t.from_riak("2100-10-05 11:10:09.000000"), dt)
+
+
+class TestJson(TestCase):
+    def test_validate(self):
+        j = Json()
+        j.validate({"foo": None})
+        self.assertRaises(ValidationError, j.validate, None)
+
+    def test_to_riak(self):
+        j = Json()
+        d = {"foo": 5}
+        self.assertEqual(j.to_riak(d), d)
+
+    def test_from_riak(self):
+        j = Json()
+        d = {"foo": [1, 2, 3]}
+        self.assertEqual(j.from_riak(d), d)
 
 
 class TestFieldWithSubtype(TestCase):


### PR DESCRIPTION
Sometimes it's nice to be able to just have a field that can store anything that can be serialized to/from JSON.
