### PR TITLE
Safaricom USSD transport needs to differentiate to_addr from input based on session

### DIFF
--- a/vumi/transports/safaricom/safaricom.py
+++ b/vumi/transports/safaricom/safaricom.py
@@ -81,24 +81,22 @@ class SafaricomTransport(HttpRpcTransport):
             return
         log.msg(('SafaricomTransport sending from %(ORIG)s to %(DEST)s '
                  'for %(SESSION_ID)s message "%(USSD_PARAMS)s"') % values)
-
-        from_addr = values['ORIG']
-        to_addr = values['DEST']
         session_id = values['SESSION_ID']
+        from_addr = values['ORIG']
+        dest = values['DEST']
         ussd_params = values['USSD_PARAMS']
-        if '*' in ussd_params:
-            history = values['USSD_PARAMS'].split('*')
-            content = history[-1]
-        else:
-            content = ''
 
         session = self.session_manager.load_session(session_id)
         if session:
             session_event = TransportUserMessage.SESSION_RESUME
+            to_addr = session['to_addr']
+            content = ussd_params.split('*')[-1]
         else:
             session_event = TransportUserMessage.SESSION_NEW
+            to_addr = '*%s*%s#' % (dest, ussd_params)
             session = self.save_session(session_id, from_addr=from_addr,
                 to_addr=to_addr)
+            content = ''
 
         yield self.publish_message(
             message_id=message_id,

--- a/vumi/transports/safaricom/tests/test_safaricom.py
+++ b/vumi/transports/safaricom/tests/test_safaricom.py
@@ -13,6 +13,7 @@ from vumi.tests.utils import FakeRedis
 class TestSafaricomTransportTestCase(TransportTestCase):
 
     transport_class = SafaricomTransport
+    timeout = 1
 
     @inlineCallbacks
     def setUp(self):
@@ -41,7 +42,7 @@ class TestSafaricomTransportTestCase(TransportTestCase):
     def mk_request(self, **params):
         defaults = {
             'ORIG': '27761234567',
-            'DEST': '*120*123#',
+            'DEST': '167',
             'SESSION_ID': 'session-id',
             'USSD_PARAMS': '',
         }
@@ -57,7 +58,7 @@ class TestSafaricomTransportTestCase(TransportTestCase):
 
         [msg] = yield self.wait_for_dispatched_messages(1)
         self.assertEqual(msg['content'], '')
-        self.assertEqual(msg['to_addr'], '*120*123#')
+        self.assertEqual(msg['to_addr'], '*167*7#')
         self.assertEqual(msg['from_addr'], '27761234567'),
         self.assertEqual(msg['session_event'],
                          TransportUserMessage.SESSION_NEW)
@@ -76,14 +77,14 @@ class TestSafaricomTransportTestCase(TransportTestCase):
     def test_inbound_resume_and_reply_with_end(self):
         # first pre-populate the redis datastore to simulate prior BEG message
         self.session_manager.create_session('session-id',
-                to_addr='120*123#', from_addr='27761234567')
+                to_addr='*167*7#', from_addr='27761234567')
         # Safaricom gives us the history of the full session in the USSD_PARAMS
         # The last submitted bit of content is the last value delimited by '*'
         deferred = self.mk_request(USSD_PARAMS='*7*a*b*c')
 
         [msg] = yield self.wait_for_dispatched_messages(1)
         self.assertEqual(msg['content'], 'c')
-        self.assertEqual(msg['to_addr'], '*120*123#')
+        self.assertEqual(msg['to_addr'], '*167*7#')
         self.assertEqual(msg['from_addr'], '27761234567')
         self.assertEqual(msg['session_event'],
                          TransportUserMessage.SESSION_RESUME)
@@ -107,3 +108,34 @@ class TestSafaricomTransportTestCase(TransportTestCase):
         self.assertEqual(json.loads(response), {
             'missing_parameter': ['DEST'],
         })
+
+    @inlineCallbacks
+    def test_to_addr_handling(self):
+        defaults = {
+            'DEST': '167',
+            'ORIG': '12345',
+            'SESSION_ID': 'session-id',
+        }
+        # initial connect
+        d1 = self.mk_full_request(USSD_PARAMS='7*1', **defaults)
+        [msg1] = yield self.wait_for_dispatched_messages(1)
+        self.assertEqual(msg1['to_addr'], '*167*7*1#')
+        self.assertEqual(msg1['content'], '')
+        self.assertEqual(msg1['session_event'],
+            TransportUserMessage.SESSION_NEW)
+        reply = TransportUserMessage(**msg1.payload).reply("hello world",
+            continue_session=True)
+        self.dispatch(reply)
+        yield d1
+
+        # follow up with the user submitting 'a'
+        d2 = self.mk_full_request(USSD_PARAMS='7*1*a', **defaults)
+        [msg1, msg2] = yield self.wait_for_dispatched_messages(2)
+        self.assertEqual(msg2['to_addr'], '*167*7*1#')
+        self.assertEqual(msg2['content'], 'a')
+        self.assertEqual(msg2['session_event'],
+            TransportUserMessage.SESSION_RESUME)
+        reply = TransportUserMessage(**msg2.payload).reply("hello world",
+            continue_session=False)
+        self.dispatch(reply)
+        yield d2


### PR DESCRIPTION
`*167*7*1#` generates the same request as dialing `*167*7#` and submitting `1` as the same input. Use the session state to determine the first number that was dialed and use that for the to_addr for subsequent requests.
