### PR TITLE
Truteq Transport should replace \r\n and \r with \n

### DIFF
--- a/vumi/transports/truteq/tests/test_truteq.py
+++ b/vumi/transports/truteq/tests/test_truteq.py
@@ -153,13 +153,13 @@ class TestTruteqTransport(TransportTestCase):
                                         client.SSMI_USSD_TYPE_EXISTING,
                                         content=u"föóbær")
 
+    @inlineCallbacks
     def _test_content_wrangling(self, submitted, expected):
         msg = self.mkmsg_out(content=submitted,
             to_addr=u"+1234", session_event=TransportUserMessage.SESSION_NONE)
         yield self.dispatch(msg)
         # Grab what was sent to Truteq
         ussd_call = yield self.dummy_connect.ussd_calls.get()
-        # We're expecting \r\n to have been replaced with \n
         data = expected.encode("utf-8")
         self.assertFalse(
             # This stuff all needs to be bytestrings by here.
@@ -168,12 +168,12 @@ class TestTruteqTransport(TransportTestCase):
                                         client.SSMI_USSD_TYPE_EXISTING))
 
     def test_handle_outbound_ussd_with_crln_in_content(self):
-        self._test_content_wrangling('hello\r\nwindows\r\nworld',
+        return self._test_content_wrangling('hello\r\nwindows\r\nworld',
                                         'hello\nwindows\nworld')
 
     def test_handle_outbound_ussd_with_cr_in_content(self):
-        self._test_content_wrangling('hello\rold mac os\rworld',
-                                        'hello\rold mac os\rworld')
+        return self._test_content_wrangling('hello\rold mac os\rworld',
+                                        'hello\nold mac os\nworld')
 
     def test_handle_inbound_sms(self):
         with LogCatcher() as logger:

--- a/vumi/transports/truteq/truteq.py
+++ b/vumi/transports/truteq/truteq.py
@@ -162,8 +162,8 @@ class TruteqTransport(Transport):
 
         # Truteq uses \r as a message delimiter in the protocol.
         # Make sure we're only sending \n for new lines.
-        text.replace('\r\n', '\n')
-        text.replace('\r', '')
+        text = text.replace('\r\n', '\n')
+        text = text.replace('\r', '\n')
 
         ssmi_session_type = self.VUMI_TO_SSMI_EVENT[message['session_event']]
         # Everything we send to ssmi_client needs to be bytestrings.


### PR DESCRIPTION
The Truteq protocol uses `\r` as an API command delimiter in their protocol.
