### PR TITLE
Make Dynamic fields initializable.

### DIFF
--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -312,6 +312,10 @@ class DynamicDescriptor(FieldDescriptor):
         else:
             self.prefix = self.field.prefix
 
+    def initialize(self, modelobj, valuedict):
+        if valuedict is not None:
+            self.update(modelobj, valuedict)
+
     def get_value(self, modelobj):
         return DynamicProxy(self, modelobj)
 
@@ -414,7 +418,6 @@ class Dynamic(FieldWithSubtype):
         the name of the field followed by a dot ('.').
     """
     descriptor_class = DynamicDescriptor
-    initializable = False
 
     def __init__(self, field_type=None, prefix=None):
         super(Dynamic, self).__init__(field_type=field_type)

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -211,6 +211,13 @@ class TestModelOnTxRiak(TestCase):
         self.assertEqual(d2.contact_info['telephone'], u"+2755")
         self.assertEqual(d2.contact_info['honorific'], u"BDFL")
 
+    def test_dynamic_field_init(self):
+        dynamic_model = self.manager.proxy(DynamicModel)
+        contact_info = {'cellphone': u'+27123',
+                        'telephone': u'+2755'}
+        d1 = dynamic_model("foo", a=u"ab", contact_info=contact_info)
+        self.assertEqual(d1.contact_info.copy(), contact_info)
+
     def test_dynamic_field_keys(self):
         d1 = self._create_dynamic_instance(self.manager.proxy(DynamicModel))
         keys = d1.contact_info.keys()


### PR DESCRIPTION
Currently Dynamic fields (from vumi.persist.fields) are not initializable. This restriciton exists because at the time it wasn't easy to implement. Since then the field infrastructure has improved to the point where it is easy to implement.
