### PR TITLE
Safaricom sends double inits, ignore first, go with second.

### DIFF
--- a/vumi/transports/safaricom/safaricom.py
+++ b/vumi/transports/safaricom/safaricom.py
@@ -84,7 +84,8 @@ class SafaricomTransport(HttpRpcTransport):
 
         session = self.session_manager.load_session(session_id)
         if session:
-            session_event = TransportUserMessage.SESSION_RESUME
+            session_event = session.get('session_event',
+                TransportUserMessage.SESSION_NEW)
             to_addr = session['to_addr']
             last_ussd_params = session['last_ussd_params']
             new_params = ussd_params.replace(last_ussd_params, '')
@@ -92,30 +93,31 @@ class SafaricomTransport(HttpRpcTransport):
                 content = new_params[1:]
             else:
                 content = ''
+
             session['last_ussd_params'] = ussd_params
-            session = self.session_manager.save_session(session_id, session)
+            session['session_event'] = TransportUserMessage.SESSION_RESUME
+            self.session_manager.save_session(session_id, session)
+
+            yield self.publish_message(
+                message_id=message_id,
+                content=content,
+                to_addr=to_addr,
+                from_addr=from_addr,
+                provider='safaricom',
+                session_event=session_event,
+                transport_type=self.transport_type,
+                transport_metadata={
+                    'safaricom': {
+                        'session_id': session_id,
+                    }
+                }
+            )
         else:
-            session_event = TransportUserMessage.SESSION_NEW
             to_addr = '*%s*%s#' % (dest, ussd_params)
-            session = self.session_manager.create_session(session_id,
+            self.session_manager.create_session(session_id,
                 from_addr=from_addr, to_addr=to_addr,
                 last_ussd_params=ussd_params)
-            content = ''
-
-        yield self.publish_message(
-            message_id=message_id,
-            content=content,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            provider='safaricom',
-            session_event=session_event,
-            transport_type=self.transport_type,
-            transport_metadata={
-                'safaricom': {
-                    'session_id': session_id,
-                }
-            }
-        )
+            self.finish_request(message_id, '', code=200)
 
     def handle_outbound_message(self, message):
         if message.payload.get('in_reply_to') and 'content' in message.payload:


### PR DESCRIPTION
The first is just an announcement of a new session starting, the second is the actual session start. Fix `event_type` fields accordingly.
