### PR TITLE
Rules-based dispatcher

### DIFF
--- a/vumi/dispatchers/base.py
+++ b/vumi/dispatchers/base.py
@@ -569,3 +569,10 @@ class RedirectOutboundRouter(BaseDispatchRouter):
         else:
             log.error('No redirect_outbound specified for %s' % (
                 transport_name,))
+
+
+class RulesBasedDispatcher(BaseDispatchWorker):
+    def __init__(self):
+        # I tyoped a pull-request creation, so now I need something to actually
+        # put in this branch.
+        raise NotImplementedError()


### PR DESCRIPTION
This comes from a conversation in `#vumi` about limitations in the existing dispatcher architecture and routing capabilities.
## overview

Instead of having a number of specialised dispatchers which each have their own routing logic, it would make sense to have a single generic dispatcher that routes based on rules. The rules would be written in a DSL that has modular matching functions, so we can add new behaviour as required.
## configuration

We'd still probably need the current "transport" and "exposed" configuration blocks to set up the routing endpoints, although we might be able to implicitly configure some of these from rules configurations.

I'd expect a rule block to look something like this:

``` yaml
    destination: myapp
    message_kind: inbound
    match: <DSL expression>
```

Where `<DSL expression>` could be something like:
- `(to_addr = 12345 OR keyword IN ['stop', 'no']) AND transport_name =~ /my_transport_.*/`
- `(to_addr_is(12345) OR keyword_in('stop', 'no')) AND transport_name_regex('my_transport_.*')`
- Something else I haven't thought of.

The first one seems slightly more intuitive to me, and I've based it fairly heavily on JIRA's issue search syntax. The second is more explicitly modular, and probably easier to implement and extend.
## implementation

I don't really know much about DSL implementation, although I'm keen to learn. I think we can map the DSL onto a bunch of matcher functions that take a message and some parameters and return a boolean.
## other stuff

We'll probably need some way to track state, and I'm not sure how easy that would be to capture in the rules language. We might need to add some functionality around the rules stuff to handle that, and some kind of pluggable component thing might be good for that.

This design is very much a work in progress, and could really use some input from people who have written dispatchers/routers or are using the ones we already have.
