### PR TITLE
Safaricom USSD transport does braindead string replacing

### DIFF
--- a/vumi/transports/safaricom/safaricom.py
+++ b/vumi/transports/safaricom/safaricom.py
@@ -81,7 +81,7 @@ class SafaricomTransport(HttpRpcTransport):
         if session:
             to_addr = session['to_addr']
             last_ussd_params = session['last_ussd_params']
-            new_params = ussd_params.replace(last_ussd_params, '')
+            new_params = ussd_params[len(last_ussd_params):]
             if new_params:
                 if last_ussd_params:
                     content = new_params[1:]

--- a/vumi/transports/safaricom/tests/test_safaricom.py
+++ b/vumi/transports/safaricom/tests/test_safaricom.py
@@ -206,14 +206,26 @@ class TestSafaricomTransportTestCase(TransportTestCase):
         self.dispatch(reply)
         yield d1
 
-        # make the exact same request again
-        d2 = self.mk_request(USSD_PARAMS='7')
+        # ask for first menu
+        d2 = self.mk_request(USSD_PARAMS='1')
         [msg1, msg2] = yield self.wait_for_dispatched_messages(2)
         self.assertEqual(msg2['to_addr'], '*167#')
-        self.assertEqual(msg2['content'], '7')
+        self.assertEqual(msg2['content'], '1')
         self.assertEqual(msg2['session_event'],
             TransportUserMessage.SESSION_RESUME)
         reply = TransportUserMessage(**msg2.payload).reply('Hello',
             continue_session=True)
         self.dispatch(reply)
         yield d2
+
+        # ask for second menu
+        d3 = self.mk_request(USSD_PARAMS='1*1')
+        [msg1, msg2, msg3] = yield self.wait_for_dispatched_messages(3)
+        self.assertEqual(msg3['to_addr'], '*167#')
+        self.assertEqual(msg3['content'], '1')
+        self.assertEqual(msg3['session_event'],
+            TransportUserMessage.SESSION_RESUME)
+        reply = TransportUserMessage(**msg3.payload).reply('Hello',
+            continue_session=True)
+        self.dispatch(reply)
+        yield d3


### PR DESCRIPTION
It replaces the contents of the previous USSD_PARAMS with `''`. If the previous entry was `1`, which happens when using a base USSD code and the first entry is provided, all subsequent `1` in following USSD_PARAMS were replaced with `''` - which breaks things.
