### PR TITLE
SMPP message decoding errors not caught

### DIFF
--- a/vumi/transports/smpp/tests/test_smpp.py
+++ b/vumi/transports/smpp/tests/test_smpp.py
@@ -867,6 +867,42 @@ class RxEsmeToSmscTestCase(TransportTestCase):
         self.assertEqual(dispatched_failures, [])
 
     @inlineCallbacks
+    def test_deliver_bad_encoding(self):
+
+        self._block_till_bind = Deferred()
+
+        # Startup
+        yield self.startTransport()
+        yield self.transport._block_till_bind
+        # The Server delivers a SMS to the Client
+
+        bad_pdu = DeliverSM(555,
+                short_message="SMS from server containing \xa7",
+                destination_addr="2772222222",
+                source_addr="2772000000",
+                )
+
+        good_pdu = DeliverSM(555,
+                short_message="Next message",
+                destination_addr="2772222222",
+                source_addr="2772000000",
+                )
+
+        self.service.factory.smsc.send_pdu(bad_pdu)
+        self.service.factory.smsc.send_pdu(good_pdu)
+        [mess] = yield self.wait_for_dispatched_messages(1)
+
+        self.assertEqual(mess['message_type'], 'user_message')
+        self.assertEqual(mess['transport_name'], self.transport_name)
+        self.assertEqual(mess['content'], "Next message")
+
+        dispatched_failures = self.get_dispatched_failures()
+        self.assertEqual(dispatched_failures, [])
+
+        [failure] = self.flushLoggedErrors(UnicodeDecodeError)
+        self.assertTrue('unexpected code byte' in failure.getErrorMessage())
+
+    @inlineCallbacks
     def test_deliver_ussd_start(self):
 
         self._block_till_bind = Deferred()

--- a/vumi/transports/smpp/transport.py
+++ b/vumi/transports/smpp/transport.py
@@ -345,10 +345,7 @@ class SmppTransport(Transport):
         #       we can't decode (e.g. data_coding == 4). We should
         #       remove the try-except once we handle such messages
         #       better.
-        try:
-            return self.publish_message(**message)
-        except Exception, e:
-            log.err(e)
+        return self.publish_message(**message).addErrback(log.err)
 
     def send_smpp(self, message):
         log.debug("Sending SMPP message: %s" % (message))


### PR DESCRIPTION
The try/except block around publishing inbound SMS messages in SMPP doesn't catch the failure from the deferred chain.
