### PR TITLE
We need to allow for raw Riak search queries via the Model base class.

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -338,5 +338,8 @@ class ModelProxy(object):
     def search(self, **kw):
         return self._modelcls.search(self._manager, **kw)
 
+    def riak_search(self, *args, **kw):
+        return self._modelcls.riak_search(self._manager, *args, **kw)
+
     def enable_search(self):
         return self._modelcls.enable_search(self._manager)


### PR DESCRIPTION
Currently it is expecting `key=value` and those are joined together with an `AND` before sending to Riak. This is cool but in certain situations we need to be able to pass in the raw query string.

See http://wiki.basho.com/Riak-Search---Querying.html and https://github.com/praekelt/vumi/blob/develop/vumi/persist/model.py#L170-184
