### PR TITLE
Dispatcher setup needs to be async

### DIFF
--- a/vumi/dispatchers/base.py
+++ b/vumi/dispatchers/base.py
@@ -6,7 +6,7 @@ import re
 import functools
 from collections import defaultdict
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
 
 from vumi.service import Worker
 from vumi.errors import ConfigError
@@ -38,6 +38,7 @@ class BaseDispatchWorker(Worker):
 
     @inlineCallbacks
     def stopWorker(self):
+        yield self.teardown_router()
         yield self.teardown_middleware()
 
     def setup_endpoints(self):
@@ -55,6 +56,10 @@ class BaseDispatchWorker(Worker):
     def setup_router(self):
         router_cls = load_class_by_string(self.config['router_class'])
         self._router = router_cls(self, self.config)
+        return maybeDeferred(self._router.setup_routing)
+
+    def teardown_router(self):
+        return maybeDeferred(self._router.teardown_routing)
 
     @inlineCallbacks
     def setup_transport_publishers(self):
@@ -155,10 +160,23 @@ class BaseDispatchRouter(object):
     def __init__(self, dispatcher, config):
         self.dispatcher = dispatcher
         self.config = config
-        self.setup_routing()
 
     def setup_routing(self):
-        """Perform setup required for routing messages."""
+        """Perform setup required for router.
+
+        :rtype: Deferred or None
+        :returns: May return a Deferred that is called when setup is
+                    complete
+        """
+        pass
+
+    def teardown_routing(self):
+        """Perform teardown required for router.
+
+        :rtype: Deferred or None
+        :returns: May return a Deferred that is called when teardown is
+                    complete
+        """
         pass
 
     def dispatch_inbound_message(self, msg):

--- a/vumi/dispatchers/tests/test_base.py
+++ b/vumi/dispatchers/tests/test_base.py
@@ -362,6 +362,8 @@ class DummyDispatcher(BaseDispatchWorker):
 
 
 class TestToAddrRouter(TestCase, MessageMakerMixIn):
+
+    @inlineCallbacks
     def setUp(self):
         self.config = {
             'transport_names': ['transport1'],
@@ -373,6 +375,7 @@ class TestToAddrRouter(TestCase, MessageMakerMixIn):
             }
         self.dispatcher = DummyDispatcher(self.config)
         self.router = ToAddrRouter(self.dispatcher, self.config)
+        yield self.router.setup_routing()
 
     def test_dispatch_inbound_message(self):
         msg = self.mkmsg_in(to_addr='to:foo:1', transport_name='transport1')
@@ -446,6 +449,8 @@ class TestTransportToTransportRouter(TestCase, MessageMakerMixIn):
 
 
 class TestFromAddrMultiplexRouter(TestCase, MessageMakerMixIn):
+
+    @inlineCallbacks
     def setUp(self):
         config = {
             "transport_names": [
@@ -463,6 +468,10 @@ class TestFromAddrMultiplexRouter(TestCase, MessageMakerMixIn):
             }
         self.dispatcher = DummyDispatcher(config)
         self.router = FromAddrMultiplexRouter(self.dispatcher, config)
+        yield self.router.setup_routing()
+
+    def tearDown(self):
+        return self.router.teardown_routing()
 
     def mkmsg_in_mux(self, content, from_addr, transport_name):
         return self.mkmsg_in(


### PR DESCRIPTION
It is currently sync-only leading to [kludgy code](https://github.com/praekelt/vumi/pull/281/files#r975609) when we need to start something async in a router (like connecting to Redis)
