### PR TITLE
Fix puppet manifest so that apt update is first

### DIFF
--- a/puppet/manifests/vumi.pp
+++ b/puppet/manifests/vumi.pp
@@ -4,7 +4,7 @@ Exec {
     user => 'vagrant',
 }
 
-# Make sure packge index is updated
+# Make sure package index is updated (when referenced by require)
 exec { "apt-get update":
     command => "apt-get update",
     user => "root",
@@ -14,7 +14,7 @@ exec { "apt-get update":
 define apt::package($ensure='latest') {
     package { $name:
         ensure => $ensure,
-        subscribe => Exec['apt-get update'];
+        require => Exec['apt-get update'];
     }
 }
 
@@ -27,19 +27,19 @@ exec { "redis-ppa":
 }
 
 # Install these packages
-package { "build-essential": ensure => latest }
-package { "python": ensure => latest }
-package { "python-dev": ensure => latest }
-package { "python-setuptools": ensure => latest }
-package { "python-software-properties": ensure => latest }
-package { "python-pip": ensure => latest }
-package { "python-virtualenv": ensure => latest }
-package { "rabbitmq-server": ensure => latest }
-package { "git-core": ensure => latest }
-package { "openjdk-6-jre-headless": ensure => latest }
-package { "libcurl3": ensure => latest }
-package { "libcurl4-openssl-dev": ensure => latest }
-package { "redis-server": ensure => latest }
+apt::package { "build-essential": ensure => latest }
+apt::package { "python": ensure => latest }
+apt::package { "python-dev": ensure => latest }
+apt::package { "python-setuptools": ensure => latest }
+apt::package { "python-software-properties": ensure => latest }
+apt::package { "python-pip": ensure => latest }
+apt::package { "python-virtualenv": ensure => latest }
+apt::package { "rabbitmq-server": ensure => latest }
+apt::package { "git-core": ensure => latest }
+apt::package { "openjdk-6-jre-headless": ensure => latest }
+apt::package { "libcurl3": ensure => latest }
+apt::package { "libcurl4-openssl-dev": ensure => latest }
+apt::package { "redis-server": ensure => latest }
 
 file {
     "/var/praekelt":


### PR DESCRIPTION
Fixes issue where debs are not found when starting Vagrant VM, because
Puppet was leaving apt-get update for last.
