### PR TITLE
Make fetch_objects the default for vumi.persist.fields.ForeignKey backlinks

### DIFF
--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -532,21 +532,17 @@ class ForeignKeyDescriptor(FieldDescriptor):
         mr = manager.riak_map_reduce()
         bucket = manager.bucket_prefix + self.cls.bucket
         mr.index(bucket, self.index_name, modelobj.key)
-        if manager.fetch_objects:
-            # Return the key and the data for this object.
-            # Allows us to populate the objects coming back from a
-            # map reduce in one single call. This is especially important
-            # for synchronous calls.
-            mr = mr.map(function="""function(v) {
-                return [[v.key, v.values[0]]]
-            }""")
+        # Return the key and the data for this object.
+        # Allows us to populate the objects coming back from a
+        # map reduce in one single call. This is especially important
+        # for synchronous calls.
+        mr = mr.map(function="""function(v) {
+            return [[v.key, v.values[0]]]
+        }""")
         return manager.run_map_reduce(mr, self.map_lookup_result)
 
-    def map_lookup_result(self, manager, link_or_result_tuple):
-        try:
-            key, result = link_or_result_tuple
-        except TypeError:
-            key, result = link_or_result_tuple.get_key(), None
+    def map_lookup_result(self, manager, result_tuple):
+        key, result = result_tuple
         return self.cls.load(manager, key, result)
 
     def get_value(self, modelobj):

--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -203,13 +203,6 @@ class Model(object):
 class Manager(object):
     """A wrapper around a Riak client."""
 
-    # By default we do not fetch the objects as part of a mapreduce call.
-    # This has the mapreduce return a list of keys which would require
-    # another set of calls to get the individual objects. For asynchronous
-    # managers this would be preferable, for synchronous managers one
-    # would likely want to fetch the objects as part of the mapreduce call.
-    fetch_objects = False
-
     def __init__(self, client, bucket_prefix):
         self.client = client
         self.bucket_prefix = bucket_prefix

--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -12,10 +12,6 @@ class RiakManager(Manager):
     """A persistence manager for the riak Python package."""
 
     call_decorator = staticmethod(flatten_generator)
-    # Since this is a synchronous manager we want to fetch objects
-    # as part of the mapreduce call. Async managers might prefer
-    # to request the objects in parallel as this could be more efficient.
-    fetch_objects = True
 
     @classmethod
     def from_config(cls, config):

--- a/vumi/persist/tests/test_riak_manager.py
+++ b/vumi/persist/tests/test_riak_manager.py
@@ -64,9 +64,6 @@ class TestRiakManager(CommonRiakManagerTests, TestCase):
         mr = self.manager.riak_map_reduce()
         mr.index('test.dummy_model', 'test_index_bin', 'test_key')
         mr.map(function='function(v) { return [[v.key, v.values[0]]] }')
-        # We should be using the sync manager and fetch the objects
-        # as part of a mapreduce call
-        self.assertTrue(self.manager.fetch_objects)
         mr_results = []
 
         def mapper(manager, key_and_result_tuple):


### PR DESCRIPTION
Curently `txriak` loads objects one by one when doing a ForeignKey backlinks look-up. It should load them all at once like the `riak` version does since that avoid O(N) http calls.
