### PR TITLE
Fixed up the Puppet path so it can find rabbitmqctl.

### DIFF
--- a/puppet/manifests/vumi.pp
+++ b/puppet/manifests/vumi.pp
@@ -1,6 +1,6 @@
 # defaults for Exec
 Exec {
-    path => ["/bin", "/usr/bin", "/usr/local/bin", "/usr/local/sbin"],
+    path => ["/bin", "/sbin", "/usr/bin", "/usr/sbin", "/usr/local/bin", "/usr/local/sbin"],
     user => 'vagrant',
 }
 


### PR DESCRIPTION
Just adding /sbin and /usr/sbin to the Puppet default exec path allows us to get the Vagrant box up and running without any errors.
