### PR TITLE
RedirectOutboundRouter fails to deal with inbounds on SMPP TX/RX

### DIFF
--- a/vumi/dispatchers/base.py
+++ b/vumi/dispatchers/base.py
@@ -570,15 +570,15 @@ class RedirectRouter(BaseDispatchRouter):
 
     def _dispatch_inbound(self, publish_function, vumi_message):
         transport_name = vumi_message['transport_name']
-        upstream = self.inbound_mappings[transport_name]
-        if not upstream:
+        redirect_to = self.inbound_mappings[transport_name]
+        if not redirect_to:
             raise ConfigError(
                 "No exposed name available for %s's inbound message: %s" % (
                 transport_name, vumi_message))
 
         msg_copy = vumi_message.copy()
-        msg_copy['transport_name'] = upstream
-        publish_function(upstream, msg_copy)
+        msg_copy['transport_name'] = redirect_to
+        publish_function(redirect_to, msg_copy)
 
     def dispatch_inbound_event(self, event):
         self._dispatch_inbound(self.dispatcher.publish_inbound_event, event)

--- a/vumi/dispatchers/tests/test_base.py
+++ b/vumi/dispatchers/tests/test_base.py
@@ -679,7 +679,6 @@ class TestRedirectOutboundRouterForSMPP(DispatcherTestCase):
     overwritten.
     """
     dispatcher_class = BaseDispatchWorker
-    timeout = 1
 
     @inlineCallbacks
     def setUp(self):


### PR DESCRIPTION
The inbounds are unable to be handled since no routing is specified and an error is raised. This looks like a configuration issue but is actually a code issue, we don't have enough configuration options to specify upstream routing.
