### PR TITLE
MessageStoreCache add_outbound_message isn't fully idempotent

### DIFF
--- a/vumi/components/message_store_cache.py
+++ b/vumi/components/message_store_cache.py
@@ -129,10 +129,11 @@ class MessageStoreCache(object):
         """
         Add a message key, weighted with the timestamp to the batch_id.
         """
-        yield self.increment_event_status(batch_id, 'sent')
-        yield self.redis.zadd(self.outbound_key(batch_id), **{
+        new_entry = yield self.redis.zadd(self.outbound_key(batch_id), **{
             message_key.encode('utf-8'): timestamp,
             })
+        if new_entry:
+            yield self.increment_event_status(batch_id, 'sent')
 
     @Manager.calls_manager
     def add_event(self, batch_id, event):

--- a/vumi/components/tests/test_message_store_cache.py
+++ b/vumi/components/tests/test_message_store_cache.py
@@ -199,6 +199,28 @@ class TestMessageStoreCache(ApplicationTestCase):
             })
 
     @inlineCallbacks
+    def test_add_outbound_message_idempotence(self):
+        for i in range(10):
+            msg = self.mkmsg_out()
+            msg['message_id'] = 'the-same-thing'
+            self.cache.add_outbound_message(self.batch_id, msg)
+        status = yield self.cache.get_event_status(self.batch_id)
+        self.assertEqual(status['sent'], 1)
+        self.assertEqual(
+            (yield self.cache.get_outbound_message_keys(self.batch_id)),
+            ['the-same-thing'])
+
+    @inlineCallbacks
+    def test_add_inbound_message_idempotence(self):
+        for i in range(10):
+            msg = self.mkmsg_in()
+            msg['message_id'] = 'the-same-thing'
+            self.cache.add_inbound_message(self.batch_id, msg)
+        self.assertEqual(
+            (yield self.cache.get_inbound_message_keys(self.batch_id)),
+            ['the-same-thing'])
+
+    @inlineCallbacks
     def test_clear_batch(self):
         msg_in = self.mkmsg_in()
         msg_out = self.mkmsg_out()


### PR DESCRIPTION
The event status is incremented without checking whether we've already seen that key or not.
