### PR TITLE
Twitter transport fixes

### DIFF
--- a/vumi/transports/twitter/twitter.py
+++ b/vumi/transports/twitter/twitter.py
@@ -36,7 +36,8 @@ class TwitterTransport(Transport):
         token = oauth.OAuthToken(self.access_token, self.access_token_secret)
         self.twitter = self._twitter_class(consumer=consumer, token=token)
         yield self.start_tracking_terms()
-        self.start_checking_for_replies()
+        if self.check_replies_interval > 0:
+            self.start_checking_for_replies()
 
     @inlineCallbacks
     def start_tracking_terms(self):
@@ -98,9 +99,9 @@ class TwitterTransport(Transport):
         conversation.
         """
         self.publish_message(
-            message_id=status.id,
+            message_id=unicode(status.id),
             content=status.text,
-            to_addr=status.in_reply_to_screen_name,
+            to_addr=status.in_reply_to_screen_name or '',
             from_addr=status.user.screen_name,
             session_event=TransportUserMessage.SESSION_NONE,
             transport_type=self.transport_type,


### PR DESCRIPTION
1. the `to_addr` can be set to `None` if no one is being addressed which trips up the middleware.
2. the message id we're passing in is an int, our stuff expects a unicode string
3. We do not always want to check for replies.
