### PR TITLE
Sandbox needs to support passing in custom environment variables

### DIFF
--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -540,6 +540,8 @@ class Sandbox(ApplicationWorker):
         the path of the executable itself).
     :param str path:
         Current working directory to run the executable in.
+    :param dict env:
+        Custom environment variables for the sandboxed process.
     :param int timeout:
         Length of time the subprocess is given to process
         a message.


### PR DESCRIPTION
The immediate use case is to set the nodejs module search path (NODE_PATH).
