### PR TITLE
SMPP ignores multipart data_coding

### DIFF
--- a/vumi/transports/smpp/clientserver/client.py
+++ b/vumi/transports/smpp/clientserver/client.py
@@ -394,11 +394,15 @@ class EsmeTransceiver(Protocol):
         if completed:
             yield self.redis.delete(redis_key)
             log.msg("Reassembled Message: %s" % (completed['message']))
+            # We assume that all parts have the same data_coding here, because
+            # otherwise there's nothing sensible we can do.
+            decoded_msg = self._decode_message(completed['message'],
+                                               pdu_params['data_coding'])
             # and we can finally pass the whole message on
             yield self.esme_callbacks.deliver_sm(
                 destination_addr=completed['to_msisdn'],
                 source_addr=completed['from_msisdn'],
-                short_message=completed['message'],
+                short_message=decoded_msg,
                 message_id=message_id,
                 )
         else:

--- a/vumi/transports/smpp/clientserver/tests/test_client.py
+++ b/vumi/transports/smpp/clientserver/tests/test_client.py
@@ -296,6 +296,15 @@ class EsmeReceiverMixin(EsmeGenericMixin):
                 "\x05\x00\x03\xff\x02\x01hello"))
 
     @inlineCallbacks
+    def test_deliver_sm_multipart_weird_coding(self):
+        esme = yield self.get_esme(
+            deliver_sm=self.assertion_cb(u'hello', 'short_message'))
+        yield esme.handle_deliver_sm(self.get_sm(
+                "\x05\x00\x03\xff\x02\x02l\x00l\x00o", 8))
+        yield esme.handle_deliver_sm(self.get_sm(
+                "\x05\x00\x03\xff\x02\x01\x00h\x00e\x00", 8))
+
+    @inlineCallbacks
     def test_deliver_sm_ussd_start(self):
         def assert_ussd(value):
             self.assertEqual('ussd', value['message_type'])


### PR DESCRIPTION
The SMPP transport ignores the `data_coding` parameter for multipart messages. This has caused at least one crash.
