### PR TITLE
ScheduleManager never handler

### DIFF
--- a/vumi/components/schedule_manager.py
+++ b/vumi/components/schedule_manager.py
@@ -28,6 +28,16 @@ class ScheduleManager(object):
        the event is scheduled for in "HH:MM:SS" format.
        The `days` field is required and specifies the days of the month the
        event is scheduled for as a list of comma/whitespace-separated integers.
+
+     * `day_of_week`
+       The `time` field is required and specifies the (approximate) time of day
+       the event is scheduled for in "HH:MM:SS" format.
+       The `days` field is required and specifies the days of the week the
+       event is scheduled for as a list of comma/whitespace-separated integers,
+       1 for Monday through 7 for Sunday.
+
+     * `never`
+       No extra fields are required and the event is never scheduled.
     """
 
     def __init__(self, schedule_definition):
@@ -40,7 +50,7 @@ class ScheduleManager(object):
         next_dt = self.get_next(then_dt)
 
         if next_dt is None:
-            # We have an invalid schedule definition.
+            # We have an invalid schedule definition or nothing scheduled.
             return False
 
         return (next_dt <= now_dt)
@@ -54,6 +64,8 @@ class ScheduleManager(object):
                 return self.get_next_day_of_month(since_dt)
             elif recurring_type == 'day_of_week':
                 return self.get_next_day_of_week(since_dt)
+            elif recurring_type == 'never':
+                return None
             else:
                 raise ValueError(
                     "Invalid value for 'recurring': %r" % (recurring_type,))

--- a/vumi/components/tests/test_schedule_manager.py
+++ b/vumi/components/tests/test_schedule_manager.py
@@ -133,3 +133,9 @@ class ScheduleManagerTestCase(TestCase):
         self.assert_config_error(
             {'recurring': 'day_of_week', 'time': '12:00:00', 'days': '8'},
             "Invalid value for 'days': '8'")
+
+    def test_never(self):
+        self.assert_schedule_next(
+            {'recurring': 'never'},
+            datetime(2012, 11, 20, 13, 0, 0),
+            None)


### PR DESCRIPTION
It's useful to be able to disable off a scheduler without tearing it down completely. A recurring type of "never" should do the trick.
