### PR TITLE
Add ability to re-write transport name to new load balancing router

### DIFF
--- a/vumi/dispatchers/tests/test_load_balancer.py
+++ b/vumi/dispatchers/tests/test_load_balancer.py
@@ -10,6 +10,7 @@ from vumi.dispatchers.load_balancer import LoadBalancingRouter
 class BaseLoadBalancingTestCase(VumiWorkerTestCase):
 
     reply_affinity = None
+    rewrite_transport_names = None
 
     @inlineCallbacks
     def setUp(self):
@@ -25,6 +26,8 @@ class BaseLoadBalancingTestCase(VumiWorkerTestCase):
         }
         if self.reply_affinity is not None:
             config['reply_affinity'] = self.reply_affinity
+        if self.rewrite_transport_names is not None:
+            config['rewrite_transport_names'] = self.rewrite_transport_names
         self.dispatcher = DummyDispatcher(config)
         self.router = LoadBalancingRouter(self.dispatcher, config)
         yield self.router.setup_routing()
@@ -37,7 +40,7 @@ class BaseLoadBalancingTestCase(VumiWorkerTestCase):
 
 class TestLoadBalancingWithoutReplyAffinity(BaseLoadBalancingTestCase):
 
-    reply_affinity = None
+    reply_affinity = False
 
     def test_inbound_message_routing(self):
         msg1 = self.mkmsg_in(content='msg 1', transport_name='transport_1')
@@ -113,3 +116,49 @@ class TestLoadBalancingWithReplyAffinity(BaseLoadBalancingTestCase):
                             "'transport_unknown' was was received" in errmsg)
         publishers = self.dispatcher.transport_publisher
         self.assertEqual(publishers['transport_1'].msgs, [msg1])
+
+
+class TestLoadBalancingWithRewriteTransportNames(BaseLoadBalancingTestCase):
+
+    rewrite_transport_names = True
+
+    def test_inbound_message_routing(self):
+        msg = self.mkmsg_in(content='msg 1', transport_name='transport_1')
+        self.router.dispatch_inbound_message(msg)
+        [new_msg] = self.dispatcher.exposed_publisher['round_robin'].msgs
+        self.assertEqual(new_msg['transport_name'], 'round_robin')
+
+    def test_inbound_event_routing(self):
+        msg = self.mkmsg_ack(transport_name='transport_1')
+        self.router.dispatch_inbound_event(msg)
+        [new_msg] = self.dispatcher.exposed_event_publisher['round_robin'].msgs
+        self.assertEqual(new_msg['transport_name'], 'round_robin')
+
+    def test_outbound_message_routing(self):
+        msg1 = self.mkmsg_out(content='msg 1', transport_name='round_robin')
+        self.router.dispatch_outbound_message(msg1)
+        [new_msg] = self.dispatcher.transport_publisher['transport_1'].msgs
+        self.assertEqual(new_msg['transport_name'], 'transport_1')
+
+
+class TestLoadBalancingWithoutRewriteTransportNames(BaseLoadBalancingTestCase):
+
+    rewrite_transport_names = False
+
+    def test_inbound_message_routing(self):
+        msg = self.mkmsg_in(content='msg 1', transport_name='transport_1')
+        self.router.dispatch_inbound_message(msg)
+        [new_msg] = self.dispatcher.exposed_publisher['round_robin'].msgs
+        self.assertEqual(new_msg['transport_name'], 'transport_1')
+
+    def test_inbound_event_routing(self):
+        msg = self.mkmsg_ack(transport_name='transport_1')
+        self.router.dispatch_inbound_event(msg)
+        [new_msg] = self.dispatcher.exposed_event_publisher['round_robin'].msgs
+        self.assertEqual(new_msg['transport_name'], 'transport_1')
+
+    def test_outbound_message_routing(self):
+        msg1 = self.mkmsg_out(content='msg 1', transport_name='round_robin')
+        self.router.dispatch_outbound_message(msg1)
+        [new_msg] = self.dispatcher.transport_publisher['transport_1'].msgs
+        self.assertEqual(new_msg['transport_name'], 'round_robin')


### PR DESCRIPTION
Otherwise dispatchers further down the line get confused.
