### PR TITLE
We need to be able to specify a QOS for application workers

### DIFF
--- a/vumi/application/base.py
+++ b/vumi/application/base.py
@@ -67,7 +67,7 @@ class ApplicationWorker(Worker):
         self._consumers = []
         self._validate_config()
         self.transport_name = self.config['transport_name']
-        self.prefetch_count = self.config.get('prefetch_count', 20)
+        self.amqp_prefetch_count = self.config.get('amqp_prefetch_count', 20)
         self.send_to_options = self.config.get('send_to', {})
 
         self._event_handlers = {
@@ -87,10 +87,8 @@ class ApplicationWorker(Worker):
         yield self.setup_application()
 
         # Apply pre-fetch limits if we need to.
-        if self.prefetch_count is not None:
-            for consumer in self._consumers:
-                yield consumer.channel.basic_qos(
-                0, int(self.prefetch_count), False)
+        if self.amqp_prefetch_count is not None:
+            yield self._setup_amqp_qos()
 
         if self.start_message_consumer:
             yield self._setup_transport_consumer()
@@ -270,3 +268,9 @@ class ApplicationWorker(Worker):
 
     def _setup_event_consumer(self):
         return self.transport_event_consumer.unpause()
+
+    @inlineCallbacks
+    def _setup_amqp_qos(self):
+        for consumer in self._consumers:
+            yield consumer.channel.basic_qos(
+                0, int(self.amqp_prefetch_count), False)

--- a/vumi/application/tests/test_base.py
+++ b/vumi/application/tests/test_base.py
@@ -231,7 +231,7 @@ class TestApplicationWorker(ApplicationTestCase):
     def test_application_prefetch_count_custom(self):
         app = yield self.get_application({
             'transport_name': 'test',
-            'prefetch_count': 10,
+            'amqp_prefetch_count': 10,
             })
         for consumer in app._consumers:
             self.assertEqual(consumer.channel.qos_prefetch_count, 10)
@@ -248,10 +248,11 @@ class TestApplicationWorker(ApplicationTestCase):
     def test_application_prefetch_count_none(self):
         app = yield self.get_application({
             'transport_name': 'test',
-            'prefetch_count': None,
+            'amqp_prefetch_count': None,
             })
         for consumer in app._consumers:
             self.assertFalse(consumer.channel.qos_prefetch_count)
+
 
 class TestApplicationMiddlewareHooks(ApplicationTestCase):
 


### PR DESCRIPTION
We're already doing this for transports: https://github.com/praekelt/vumi/blob/develop/vumi/transports/base.py#L128

In the transport this is called `concurrent_sends` but I'm calling it `prefetch_count` instead as that makes more in the general (non-transport case)
