### PR TITLE
vumi.persist.Model instances need to be iterable.

### DIFF
--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -70,11 +70,6 @@ class FieldDescriptor(object):
         the data from Riak."""
         pass
 
-    def export_value(self, modelobj):
-        """Export the value of this descriptor in a format that can be
-        converted to JSON, YAML, etc..."""
-        return self.get_value(modelobj)
-
     def __repr__(self):
         return "<%s key=%s field=%r>" % (self.__class__.__name__, self.key,
                                          self.field)
@@ -355,9 +350,6 @@ class DynamicDescriptor(FieldDescriptor):
     def get_value(self, modelobj):
         return DynamicProxy(self, modelobj)
 
-    def export_value(self, modelobj):
-        return sorted(self.get_value(modelobj).items())
-
     def set_value(self, modelobj, value):
         raise RuntimeError("DynamicDescriptors should never be assigned to.")
 
@@ -468,9 +460,6 @@ class ListOfDescriptor(FieldDescriptor):
 
     def get_value(self, modelobj):
         return ListProxy(self, modelobj)
-
-    def export_value(self, modelobj):
-        return list(self.get_value(modelobj))
 
     def __set__(self, modelobj, values):
         # override __set__ to do custom validation
@@ -584,9 +573,6 @@ class ForeignKeyDescriptor(FieldDescriptor):
     def get_value(self, modelobj):
         return ForeignKeyProxy(self, modelobj)
 
-    def export_value(self, modelobj):
-        return self.get_value(modelobj).key
-
     def get_foreign_key(self, modelobj):
         return modelobj._riak_object._data.get(self.key)
 
@@ -674,9 +660,6 @@ class ManyToManyDescriptor(ForeignKeyDescriptor):
 
     def get_value(self, modelobj):
         return ManyToManyProxy(self, modelobj)
-
-    def export_value(self, modelobj):
-        return sorted(self.get_value(modelobj).keys())
 
     def set_value(self, modelobj, value):
         raise RuntimeError("ManyToManyDescriptors should never be assigned"

--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -206,25 +206,27 @@ class Model(object):
         self.clean()
 
     def __repr__(self):
-        str_items = ["%s=%r" % item for item in self.get_items()]
+        str_items = ["%s=%r" % item for item
+                        in sorted(self.get_data().items())]
         return "<%s %s>" % (self.__class__.__name__, " ".join(str_items))
 
     def clean(self):
         for field_name, descriptor in self.field_descriptors.iteritems():
             descriptor.clean(self)
 
-    def get_items(self):
+    def get_data(self):
         """
-        Returns a list of (key, value) tuples for all known field descriptors.
+        Returns a dictionary with for all known field names & values.
         Useful for when needing to represent a model instance as a dictionary.
 
         :returns:
-            A list of (key, value) tuples.
+            A dict of all values, including the key.
         """
-        return [('key', self.key)] + [
-                    (field_name, descriptor.export_value(self))
-                    for field_name, descriptor
-                    in sorted(self.field_descriptors.items())]
+        data = self._riak_object.get_data()
+        data.update({
+            'key': self.key,
+            })
+        return data
 
     def save(self):
         """Save the object to Riak.


### PR DESCRIPTION
Sometimes one wants to be able to represent the model instance as a dict (for say converting to JSON) and having an iterable `Model` instance makes that much easier.

Currently we can get access to `_riak_object.get_data()` but that's too much groveling and it doesn't have all of the necessary metadata stored in Riak secondary indexes available to us.
