### PR TITLE
Allow optional headers in HttpRpcTransport's responses

### DIFF
--- a/vumi/transports/httprpc/httprpc.py
+++ b/vumi/transports/httprpc/httprpc.py
@@ -195,8 +195,8 @@ class HttpRpcTransport(Transport):
             repr(data),))
         request = self.get_request(request_id)
         if request:
-            for h_name, h_value in headers.iteritems():
-                request.responseHeaders.setRawHeaders(h_name, [h_value])
+            for h_name, h_values in headers.iteritems():
+                request.responseHeaders.setRawHeaders(h_name, h_values)
             request.setResponseCode(code)
             request.write(data)
             request.finish()

--- a/vumi/transports/httprpc/tests/test_httprpc.py
+++ b/vumi/transports/httprpc/tests/test_httprpc.py
@@ -130,8 +130,8 @@ class TestJSONTransport(TransportTestCase):
 
 class CustomOutboundTransport(OkTransport):
     RESPONSE_HEADERS = {
-        'Darth-Vader': 'Anakin Skywalker',
-        'Admiral-Ackbar': 'Its a trap!'
+        'Darth-Vader': ['Anakin Skywalker'],
+        'Admiral-Ackbar': ['Its a trap!', 'Shark']
     }
 
     def handle_outbound_message(self, message):
@@ -171,4 +171,4 @@ class TestCustomOutboundTransport(TransportTestCase):
             ['Anakin Skywalker'])
         self.assertEqual(
             response.headers.getRawHeaders('Admiral-Ackbar'),
-            ['Its a trap!'])
+            ['Its a trap!', 'Shark'])


### PR DESCRIPTION
`HttpRpcTransport`'s `finish_request()` handles responses to http requests. `finish_request()` accepts the response body's data and the response code as arguments. However, it does not allow headers to be added to the response. This could be changed, such that `finish_request()` allows headers to be passed in as an optional param.

This change is needed for integration with IMImobile's HTTP API for USSD. While a workaround is possible (overriding `finish_request()` and copying most of its code, or working with `_requests` directly), allowing an optional header arg in `HttpRpcTransport`'s `finish_request()` seems cleaner and less repetitive, and may be needed in future for other transports subclassing `HttpRpcTransport`.
