### PR TITLE
HTTP headers should be bytes, not unicode

### DIFF
--- a/vumi/components/message_store_api.py
+++ b/vumi/components/message_store_api.py
@@ -58,7 +58,7 @@ class MatchResource(resource.Resource):
 
     def _add_resp_header(self, request, key, value):
         if isinstance(value, unicode):
-            value = unicode.encode('utf-8')
+            value = value.encode('utf-8')
         if not isinstance(value, str):
             raise TypeError("HTTP header values must be bytes.")
         request.responseHeaders.addRawHeader(key, value)


### PR DESCRIPTION
Since Twisted 12.3:
`[...]/twisted/web/server.py:220: DeprecationWarning: Passing non-bytes header values is deprecated since Twisted 12.3. Pass only bytes instead.`
