### PR TITLE
The Cellulant USSD transport sends the from addr as the connect when a new message starts.

### DIFF
--- a/vumi/transports/cellulant/cellulant.py
+++ b/vumi/transports/cellulant/cellulant.py
@@ -67,6 +67,7 @@ class CellulantTransport(HttpRpcTransport):
         to_addr = None
         if op_code == "BEG":
             to_addr = request.args.get('INPUT')[0]
+            content = None
             yield self.set_ussd_for_msisdn_session(
                 request.args.get('MSISDN')[0],
                 request.args.get('sessionID')[0],
@@ -75,6 +76,7 @@ class CellulantTransport(HttpRpcTransport):
             to_addr = yield self.get_ussd_for_msisdn_session(
                 request.args.get('MSISDN')[0],
                 request.args.get('sessionID')[0])
+            content = request.args.get('INPUT')[0]
 
         if ((request.args.get('ABORT')[0] not in ('0', 'null'))
             or (op_code == 'ABO')):
@@ -95,7 +97,7 @@ class CellulantTransport(HttpRpcTransport):
             }
             self.publish_message(
                 message_id=message_id,
-                content=request.args.get('INPUT')[0],
+                content=content,
                 to_addr=to_addr,
                 from_addr=request.args.get('MSISDN')[0],
                 session_event=event,

--- a/vumi/transports/cellulant/tests/test_cellulant.py
+++ b/vumi/transports/cellulant/tests/test_cellulant.py
@@ -55,7 +55,7 @@ class TestCellulantTransportTestCase(TransportTestCase):
         deferred = self.mk_request(INPUT="*120*1#")
 
         [msg] = yield self.wait_for_dispatched_messages(1)
-        self.assertEqual(msg['content'], '*120*1#')
+        self.assertEqual(msg['content'], None)
         self.assertEqual(msg['to_addr'], '*120*1#')
         self.assertEqual(msg['from_addr'], '27761234567'),
         self.assertEqual(msg['session_event'],


### PR DESCRIPTION
It should send `None` instead.
