### PR TITLE
WindowManager leaves keys lying around

### DIFF
--- a/vumi/components/tests/test_window_manager.py
+++ b/vumi/components/tests/test_window_manager.py
@@ -84,6 +84,29 @@ class WindowManagerTestCase(TestCase, PersistenceMixin):
         self.assertTrue(next_flight_key)
 
     @inlineCallbacks
+    def test_set_and_external_id(self):
+        yield self.wm.set_external_id(self.window_id, "flight_key",
+                                      "external_id")
+        self.assertEqual(
+            (yield self.wm.get_external_id(self.window_id, "flight_key")),
+            "external_id")
+        self.assertEqual(
+            (yield self.wm.get_internal_id(self.window_id, "external_id")),
+            "flight_key")
+
+    @inlineCallbacks
+    def test_remove_key_removes_external_and_internal_id(self):
+        yield self.wm.set_external_id(self.window_id, "flight_key",
+                                      "external_id")
+        yield self.wm.remove_key(self.window_id, "flight_key")
+        self.assertEqual(
+            (yield self.wm.get_external_id(self.window_id, "flight_key")),
+            None)
+        self.assertEqual(
+            (yield self.wm.get_internal_id(self.window_id, "external_id")),
+            None)
+
+    @inlineCallbacks
     def assert_count_waiting(self, window_id, amount):
         self.assertEqual((yield self.wm.count_waiting(window_id)), amount)
 

--- a/vumi/components/window_manager.py
+++ b/vumi/components/window_manager.py
@@ -169,12 +169,17 @@ class WindowManager(object):
     def get_internal_id(self, window_id, external_id):
         return self.redis.get(self.map_key(window_id, 'internal', external_id))
 
+    def get_external_id(self, window_id, flight_key):
+        return self.redis.get(self.map_key(window_id, 'external', flight_key))
+
+    @inlineCallbacks
     def clear_external_id(self, window_id, flight_key):
-        external_id = yield self.redis.delete(self.map_key(window_id,
-            'external', flight_key))
+        external_id = yield self.get_external_id(window_id, flight_key)
         if external_id:
+            yield self.redis.delete(self.map_key(window_id, 'external',
+                                                 flight_key))
             yield self.redis.delete(self.map_key(window_id, 'internal',
-                external_id))
+                                                 external_id))
 
     def monitor(self, key_callback, interval=10, cleanup=True,
                 cleanup_callback=None):


### PR DESCRIPTION
```
$ redis-cli -n 1 KEYS *window_manager* | wc -l
2702055
```

`clear_external_id()` is missing an `@inlineCallbacks` decorator: https://github.com/praekelt/vumi/blob/develop/vumi/components/window_manager.py#L172 
