### PR TITLE
telnet transport should be able to manually set the to_addr

### DIFF
--- a/vumi/transports/telnet/telnet.py
+++ b/vumi/transports/telnet/telnet.py
@@ -43,10 +43,15 @@ class TelnetServerTransport(Transport):
     :type telnet_port: int
     :param telnet_port:
         Port for the telnet server to listen on.
+    :type to_addr: str
+    :param to_addr:
+        The to_addr to use for the telnet server.
+        Defaults to 'host:port'.
     """
 
     def validate_config(self):
         self.telnet_port = int(self.config['telnet_port'])
+        self._to_addr = self.config.get('to_addr')
 
     @inlineCallbacks
     def setup_transport(self):
@@ -59,7 +64,8 @@ class TelnetServerTransport(Transport):
         factory.protocol = protocol
         self.telnet_server = yield reactor.listenTCP(self.telnet_port,
                                                      factory)
-        self._to_addr = self._format_addr(self.telnet_server.getHost())
+        if self._to_addr is None:
+            self._to_addr = self._format_addr(self.telnet_server.getHost())
 
     @inlineCallbacks
     def teardown_transport(self):

--- a/vumi/transports/telnet/tests/test_telnet.py
+++ b/vumi/transports/telnet/tests/test_telnet.py
@@ -147,3 +147,14 @@ class TelnetServerTransportTestCase(TransportTestCase):
         line = yield self.client.transport.protocol.queue.get()
         self.assertEqual(line, "send_foo")
         self.assertTrue(self.client.transport.connected)
+
+    @inlineCallbacks
+    def test_to_addr_override(self):
+        old_worker = self.worker
+        self.assertEqual(old_worker._to_addr,
+            old_worker._format_addr(old_worker.telnet_server.getHost()))
+        worker = yield self.get_transport({
+            'telnet_port': 0,
+            'to_addr': 'foo'
+        })
+        self.assertEqual(worker._to_addr, 'foo')


### PR DESCRIPTION
This allows us to fake incoming addresses & test routing better.
