### PR TITLE
We need a last value aggregator in blinkenlights

### DIFF
--- a/vumi/blinkenlights/metrics.py
+++ b/vumi/blinkenlights/metrics.py
@@ -129,6 +129,7 @@ AVG = Aggregator("avg",
                  lambda values: sum(values) / len(values) if values else 0.0)
 MAX = Aggregator("max", lambda values: max(values) if values else 0.0)
 MIN = Aggregator("min", lambda values: min(values) if values else 0.0)
+LAST = Aggregator("last", lambda values: values[-1] if values else 0.0)
 
 
 class MetricRegistrationError(Exception):

--- a/vumi/blinkenlights/metrics_workers.py
+++ b/vumi/blinkenlights/metrics_workers.py
@@ -223,10 +223,11 @@ class MetricAggregator(Worker):
                 ts = ts_key * self.bucket_size
                 items = self.buckets[ts_key].iteritems()
                 for metric_name, (agg_set, values) in items:
+                    values = [v for t, v in sorted(values)]
                     for agg_name in agg_set:
                         agg_metric = "%s.%s" % (metric_name, agg_name)
                         agg_func = Aggregator.from_name(agg_name)
-                        agg_value = agg_func([v[1] for v in values])
+                        agg_value = agg_func(values)
                         aggregates.append((agg_metric, agg_value))
 
                 for agg_metric, agg_value in aggregates:

--- a/vumi/blinkenlights/tests/test_metrics.py
+++ b/vumi/blinkenlights/tests/test_metrics.py
@@ -141,26 +141,37 @@ class TestAggregators(TestCase):
     def test_sum(self):
         self.assertEqual(metrics.SUM([]), 0.0)
         self.assertEqual(metrics.SUM([1.0, 2.0]), 3.0)
+        self.assertEqual(metrics.SUM([2.0, 1.0]), 3.0)
         self.assertEqual(metrics.SUM.name, "sum")
         self.assertEqual(metrics.Aggregator.from_name("sum"), metrics.SUM)
 
     def test_avg(self):
         self.assertEqual(metrics.AVG([]), 0.0)
         self.assertEqual(metrics.AVG([1.0, 2.0]), 1.5)
+        self.assertEqual(metrics.AVG([2.0, 1.0]), 1.5)
         self.assertEqual(metrics.AVG.name, "avg")
         self.assertEqual(metrics.Aggregator.from_name("avg"), metrics.AVG)
 
     def test_min(self):
         self.assertEqual(metrics.MIN([]), 0.0)
         self.assertEqual(metrics.MIN([1.0, 2.0]), 1.0)
+        self.assertEqual(metrics.MIN([2.0, 1.0]), 1.0)
         self.assertEqual(metrics.MIN.name, "min")
         self.assertEqual(metrics.Aggregator.from_name("min"), metrics.MIN)
 
     def test_max(self):
         self.assertEqual(metrics.MAX([]), 0.0)
         self.assertEqual(metrics.MAX([1.0, 2.0]), 2.0)
+        self.assertEqual(metrics.MAX([2.0, 1.0]), 2.0)
         self.assertEqual(metrics.MAX.name, "max")
         self.assertEqual(metrics.Aggregator.from_name("max"), metrics.MAX)
+
+    def test_last(self):
+        self.assertEqual(metrics.LAST([]), 0.0)
+        self.assertEqual(metrics.LAST([1.0, 2.0]), 2.0)
+        self.assertEqual(metrics.LAST([2.0, 1.0]), 1.0)
+        self.assertEqual(metrics.LAST.name, "last")
+        self.assertEqual(metrics.Aggregator.from_name("last"), metrics.LAST)
 
     def test_already_registered(self):
         self.assertRaises(metrics.AggregatorAlreadyDefinedError,


### PR DESCRIPTION
The min and max metrics published in our vumi campaigns should in fact be named 'last' metrics, since we publish totals for these metrics. This means we need a `LAST` aggregator in blinkenlights.
