### PR TITLE
vumi bridge transport ignores session_event param

### DIFF
--- a/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
@@ -103,6 +103,7 @@ class GoConversationTransportTestCase(TransportTestCase):
     @inlineCallbacks
     def test_sending_messages(self):
         msg = self.mkmsg_out()
+        msg['session_event'] = TransportUserMessage.SESSION_CLOSE
         d = self.dispatch(msg)
         req = yield self.get_next_request()
         received_msg = json.loads(req.content.read())
@@ -111,6 +112,7 @@ class GoConversationTransportTestCase(TransportTestCase):
             'in_reply_to': None,
             'to_addr': msg['to_addr'],
             'message_id': msg['message_id'],
+            'session_event': TransportUserMessage.SESSION_CLOSE
         })
 
         remote_id = TransportUserMessage.generate_id()

--- a/vumi/transports/vumi_bridge/vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/vumi_bridge.py
@@ -116,6 +116,7 @@ class GoConversationTransport(Transport):
             'content': message['content'],
             'message_id': message['message_id'],
             'in_reply_to': message['in_reply_to'],
+            'session_event': message['session_event']
         }
 
         resp = yield http_request_full(


### PR DESCRIPTION
needed for things like closing USSD sessions
