### PR TITLE
Production Airtel USSD fixes

### DIFF
--- a/vumi/transports/airtel/tests/test_airtel.py
+++ b/vumi/transports/airtel/tests/test_airtel.py
@@ -96,12 +96,11 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
         # first pre-populate the redis datastore to simulate prior BEG message
         yield self.session_manager.create_session(self.session_id,
                 to_addr='*167*7#', from_addr='27761234567',
-                last_ussd_params='*167*7*a*b',
                 session_event=TransportUserMessage.SESSION_RESUME)
 
         # Safaricom gives us the history of the full session in the USSD_PARAMS
         # The last submitted bit of content is the last value delimited by '*'
-        deferred = self.mk_ussd_request('167*7*a*b*c')
+        deferred = self.mk_ussd_request('c')
 
         [msg] = yield self.wait_for_dispatched_messages(1)
         self.assertEqual(msg['content'], 'c')
@@ -140,7 +139,7 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
         yield d1
 
         # follow up with the user submitting 'a'
-        d2 = self.mk_ussd_request('167*7*1*a')
+        d2 = self.mk_ussd_request('a')
         [msg1, msg2] = yield self.wait_for_dispatched_messages(2)
         self.assertEqual(msg2['to_addr'], '*167*7*1#')
         self.assertEqual(msg2['content'], 'a')
@@ -165,7 +164,7 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
         yield d1
 
         # make the exact same request again
-        d2 = self.mk_ussd_request('167*7*3')
+        d2 = self.mk_ussd_request('')
         [msg1, msg2] = yield self.wait_for_dispatched_messages(2)
         self.assertEqual(msg2['to_addr'], '*167*7*3#')
         self.assertEqual(msg2['content'], '')
@@ -179,10 +178,9 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
     @inlineCallbacks
     def test_submitting_asterisks_as_values(self):
         yield self.session_manager.create_session(self.session_id,
-                to_addr='*167*7#', from_addr='27761234567',
-                last_ussd_params='*167*7*a*b')
+                to_addr='*167*7#', from_addr='27761234567')
         # we're submitting a bunch of *s
-        deferred = self.mk_ussd_request('167*7*a*b*****')
+        deferred = self.mk_ussd_request('****')
 
         [msg] = yield self.wait_for_dispatched_messages(1)
         self.assertEqual(msg['content'], '****')
@@ -191,16 +189,13 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
             continue_session=True)
         self.dispatch(reply)
         yield deferred
-        session = yield self.session_manager.load_session(self.session_id)
-        self.assertEqual(session['last_ussd_params'], '*167*7*a*b*****')
 
     @inlineCallbacks
     def test_submitting_asterisks_as_values_after_asterisks(self):
         yield self.session_manager.create_session(self.session_id,
-                to_addr='*167*7#', from_addr='27761234567',
-                last_ussd_params='*167*7*a*b**')
+                to_addr='*167*7#', from_addr='27761234567')
         # we're submitting a bunch of *s
-        deferred = self.mk_ussd_request('167*7*a*b*****')
+        deferred = self.mk_ussd_request('**')
 
         [msg] = yield self.wait_for_dispatched_messages(1)
         self.assertEqual(msg['content'], '**')
@@ -209,8 +204,6 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
             continue_session=True)
         self.dispatch(reply)
         yield deferred
-        session = yield self.session_manager.load_session(self.session_id)
-        self.assertEqual(session['last_ussd_params'], '*167*7*a*b*****')
 
     @inlineCallbacks
     def test_submitting_with_base_code_empty_ussd_params(self):
@@ -226,7 +219,7 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
         yield d1
 
         # ask for first menu
-        d2 = self.mk_ussd_request('167*1')
+        d2 = self.mk_ussd_request('1')
         [msg1, msg2] = yield self.wait_for_dispatched_messages(2)
         self.assertEqual(msg2['to_addr'], '*167#')
         self.assertEqual(msg2['content'], '1')
@@ -238,7 +231,7 @@ class TestAirtelUSSDTransportTestCase(TransportTestCase):
         yield d2
 
         # ask for second menu
-        d3 = self.mk_ussd_request('167*1*1')
+        d3 = self.mk_ussd_request('1')
         [msg1, msg2, msg3] = yield self.wait_for_dispatched_messages(3)
         self.assertEqual(msg3['to_addr'], '*167#')
         self.assertEqual(msg3['content'], '1')


### PR DESCRIPTION
1. Use the SessionID, we're getting it consistently even though the docs say we won't. 
2. The input parameter provides the USSD code on the first connection, and full input for subsequent connections, it isn't appended like Safaricom does.
