### PR TITLE
Better error logging when vumi_bridge transport fails to parse JSON messages.

### DIFF
--- a/vumi/transports/vumi_bridge/tests/test_client.py
+++ b/vumi/transports/vumi_bridge/tests/test_client.py
@@ -4,7 +4,8 @@ from twisted.web.server import NOT_DONE_YET
 from twisted.web.client import ResponseDone
 
 from vumi.tests.utils import MockHttpServer
-from vumi.transports.vumi_bridge.client import StreamingClient
+from vumi.transports.vumi_bridge.client import (
+    StreamingClient, VumiBridgeInvalidJsonError)
 from vumi.message import Message
 
 
@@ -49,3 +50,15 @@ class ClientTestCase(TestCase):
         # this is the error message we get when a ResponseDone is raised
         # which happens when the remote server closes the connection.
         self.assertEqual(reason, 'Response body fully received')
+
+    @inlineCallbacks
+    def test_invalid_json(self):
+        req = yield self.mock_server.queue.get()
+        req.write("Hello\n")
+        req.finish()
+        try:
+            yield self.errors_received.get()
+        except VumiBridgeInvalidJsonError, e:
+            self.assertEqual(e.args, ("Hello",))
+        else:
+            self.fail("Expected VumiBridgeInvalidJsonError.")


### PR DESCRIPTION
Currently messages like:

```
2013-06-16 17:00:08+0200 [HTTP11ClientProtocol (TLSMemoryBIOProtocol),client] Unhandled Error
        Traceback (most recent call last):
        Failure: exceptions.ValueError: No JSON object could be decoded
```

are logged and they're not very useful for debugging.
