### PR TITLE
Fix test skipping when Riak is unavailable

### DIFF
--- a/vumi/components/tests/test_message_store.py
+++ b/vumi/components/tests/test_message_store.py
@@ -8,7 +8,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.message import TransportEvent
 from vumi.application.tests.test_base import ApplicationTestCase
-from vumi.components.message_store import MessageStore
+from vumi.tests.utils import import_skip
 
 
 class TestMessageStoreBase(ApplicationTestCase):
@@ -19,6 +19,10 @@ class TestMessageStoreBase(ApplicationTestCase):
     @inlineCallbacks
     def setUp(self):
         yield super(TestMessageStoreBase, self).setUp()
+        try:
+            from vumi.components.message_store import MessageStore
+        except ImportError, e:
+            import_skip(e, 'riakasaurus', 'riakasaurus.riak')
         self.redis = yield self.get_redis_manager()
         self.manager = self.get_riak_manager()
         self.store = MessageStore(self.manager, self.redis)

--- a/vumi/components/tests/test_message_store_cache.py
+++ b/vumi/components/tests/test_message_store_cache.py
@@ -8,7 +8,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.message import TransportMessage
 from vumi.application.tests.test_base import ApplicationTestCase
-from vumi.components.message_store import MessageStore
+from vumi.tests.utils import import_skip
 
 
 class TestMessageStoreCache(ApplicationTestCase):
@@ -17,6 +17,10 @@ class TestMessageStoreCache(ApplicationTestCase):
     @inlineCallbacks
     def setUp(self):
         yield super(TestMessageStoreCache, self).setUp()
+        try:
+            from vumi.components.message_store import MessageStore
+        except ImportError, e:
+            import_skip(e, 'riakasaurus', 'riakasaurus.riak')
         self.redis = yield self.get_redis_manager()
         self.manager = yield self.get_riak_manager()
         self.store = yield MessageStore(self.manager, self.redis)

--- a/vumi/persist/tests/test_txriak_manager.py
+++ b/vumi/persist/tests/test_txriak_manager.py
@@ -6,8 +6,6 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.persist.model import Manager
 from vumi.tests.utils import import_skip
 
-from riakasaurus import transport
-
 
 class DummyModel(object):
 
@@ -212,8 +210,11 @@ class TestTxRiakManager(CommonRiakManagerTests, TestCase):
     def setUp(self):
         try:
             from vumi.persist.txriak_manager import TxRiakManager
+            from riakasaurus import transport
         except ImportError, e:
             import_skip(e, 'riakasaurus', 'riakasaurus.riak')
+        self.pbc_transport = transport.PBCTransport
+        self.http_transport = transport.HTTPTransport
         self.manager = TxRiakManager.from_config({'bucket_prefix': 'test.'})
         yield self.manager.purge_all()
 
@@ -230,7 +231,7 @@ class TestTxRiakManager(CommonRiakManagerTests, TestCase):
             'bucket_prefix': 'test.',
             })
         self.assertEqual(type(manager.client.transport),
-            transport.PBCTransport)
+                         self.pbc_transport)
         return manager.client.transport.quit()
 
     def test_transport_class_http(self):
@@ -240,7 +241,7 @@ class TestTxRiakManager(CommonRiakManagerTests, TestCase):
             'bucket_prefix': 'test.',
             })
         self.assertEqual(type(manager.client.transport),
-            transport.HTTPTransport)
+                         self.http_transport)
 
     def test_transport_class_default(self):
         manager_class = type(self.manager)
@@ -248,4 +249,4 @@ class TestTxRiakManager(CommonRiakManagerTests, TestCase):
             'bucket_prefix': 'test.',
             })
         self.assertEqual(type(manager.client.transport),
-            transport.HTTPTransport)
+                         self.http_transport)


### PR DESCRIPTION
We've had a few extra Riak usages sneak in since we last tested that our test skipping worked.
