### PR TITLE
Creating a new session in SessionManager does not clear a session that may already exist

### DIFF
--- a/vumi/components/session.py
+++ b/vumi/components/session.py
@@ -83,6 +83,7 @@ class SessionManager(object):
         """
         Create a new session using the given user_id
         """
+        yield self.clear_session(user_id)
         defaults = {
             'created_at': time.time()
         }

--- a/vumi/components/tests/test_session.py
+++ b/vumi/components/tests/test_session.py
@@ -56,6 +56,18 @@ class SessionManagerTestCase(TestCase, PersistenceMixin):
         self.assertEqual(loaded, session)
 
     @inlineCallbacks
+    def test_create_clears_existing_session(self):
+        session = yield self.sm.create_session("u1", foo="bar")
+        self.assertEqual(sorted(session.keys()), ['created_at', 'foo'])
+        loaded = yield self.sm.load_session("u1")
+        self.assertEqual(loaded, session)
+
+        session = yield self.sm.create_session("u1", bar="baz")
+        self.assertEqual(sorted(session.keys()), ['bar', 'created_at'])
+        loaded = yield self.sm.load_session("u1")
+        self.assertEqual(loaded, session)
+
+    @inlineCallbacks
     def test_save_session(self):
         test_session = {"foo": 5, "bar": "baz"}
         yield self.sm.create_session("u1")


### PR DESCRIPTION
This is biting us in the wikipedia app.
