### PR TITLE
Truteq transport is broken when using newer python-ssmi

### DIFF
--- a/vumi/transports/truteq/truteq.py
+++ b/vumi/transports/truteq/truteq.py
@@ -177,7 +177,6 @@ class TruteqTransport(Transport):
         text = text.replace('\r', '\n')
 
         ssmi_session_type = self.VUMI_TO_SSMI_EVENT[message['session_event']]
-        # Everything we send to ssmi_client needs to be bytestrings.
-        data = text.encode(self.SSMI_ENCODING)
+        # We need to send unicode data to ssmi_client, but bytes for msisdn.
         msisdn = message['to_addr'].strip('+').encode(self.SSMI_ENCODING)
-        self.ssmi_client.send_ussd(msisdn, data, ssmi_session_type)
+        self.ssmi_client.send_ussd(msisdn, text, ssmi_session_type)


### PR DESCRIPTION
New python-ssmi calls `.encode()` on the data you give it, which breaks horribly if you already have a bytestring in a non-ASCII encoding. Old python-ssmi called `str()` on it, which breaks if you give it unicode containing non-ASCII characters.
