### PR TITLE
RedisResource for Sandbox should allow for a grace period for number of keys allowed.

### DIFF
--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -271,17 +271,21 @@ class RedisResource(SandboxResource):
     :param int keys_per_user_soft:
         Maximum number of keys each user may make use of in redis
         before usage warnings are logged.
-        (default: 80).
+        (default: 80% of hard limit).
     :param int keys_per_user_hard:
         Maximum number of keys each user may make use of in redis
-        (default: 100).
+        (default: 100). Falls back to keys_per_user.
+    :param int keys_per_user:
+        Synonym for `keys_per_user_hard`. Deprecated.
     """
 
     @inlineCallbacks
     def setup(self):
         self.r_config = self.config.get('redis_manager', {})
-        self.keys_per_user_soft = self.config.get('keys_per_user_soft', 80)
-        self.keys_per_user_hard = self.config.get('keys_per_user_hard', 100)
+        self.keys_per_user_hard = self.config.get(
+            'keys_per_user_hard', self.config.get('keys_per_user', 100))
+        self.keys_per_user_soft = self.config.get(
+            'keys_per_user_soft', int(0.8 * self.keys_per_user_hard))
         self.redis = yield TxRedisManager.from_config(self.r_config)
 
     def teardown(self):

--- a/vumi/application/tests/test_sandbox.py
+++ b/vumi/application/tests/test_sandbox.py
@@ -16,7 +16,7 @@ from twisted.trial.unittest import TestCase, SkipTest
 from vumi.message import TransportUserMessage, TransportEvent
 from vumi.application.tests.utils import ApplicationTestCase
 from vumi.application.sandbox import (
-    Sandbox, SandboxApi, SandboxCommand, SandboxError, SandboxResources,
+    Sandbox, SandboxApi, SandboxCommand, SandboxResources,
     SandboxResource, RedisResource, OutboundResource, JsSandboxResource,
     LoggingResource, HttpClientResource, JsSandbox, JsFileSandbox)
 from vumi.tests.utils import LogCatcher, PersistenceMixin
@@ -580,11 +580,14 @@ class TestRedisResource(ResourceTestCaseBase, PersistenceMixin):
         super(TestRedisResource, self).setUp()
         yield self._persist_setUp()
         self.r_server = yield self.get_redis_manager()
-        yield self.create_resource({
-            'redis_manager': {
-                'FAKE_REDIS': self.r_server,
-                'key_prefix': self.r_server._key_prefix,
-            }})
+        yield self.create_resource({})
+
+    def create_resource(self, config):
+        config.setdefault('redis_manager', {
+            'FAKE_REDIS': self.r_server,
+            'key_prefix': self.r_server._key_prefix,
+        })
+        return super(TestRedisResource, self).create_resource(config)
 
     @inlineCallbacks
     def tearDown(self):
@@ -611,6 +614,12 @@ class TestRedisResource(ResourceTestCaseBase, PersistenceMixin):
         self.assertEqual((yield self.r_server.get(count_key)),
                          str(total_count))
 
+    def assert_api_log(self, expected_level, expected_message):
+        [log_entry] = self.api.logs
+        level, message = log_entry
+        self.assertEqual(level, expected_level)
+        self.assertEqual(message, expected_message)
+
     @inlineCallbacks
     def test_handle_set(self):
         reply = yield self.dispatch_command('set', key='foo', value='bar')
@@ -622,14 +631,12 @@ class TestRedisResource(ResourceTestCaseBase, PersistenceMixin):
         yield self.create_metric('foo', 'a', total_count=80)
         reply = yield self.dispatch_command('set', key='bar', value='bar')
         self.check_reply(reply, success=True)
-        [limit_warning] = self.api.logs
-        level, message = limit_warning
-        self.assertEqual(level, logging.WARNING)
-        self.assertEqual(
-            message,
+        self.assert_api_log(
+            logging.WARNING,
             'Redis soft limit of 80 keys reached for sandbox test_id. '
             'Once the hard limit of 100 is reached no more keys can '
-            'be written.')
+            'be written.'
+        )
 
     @inlineCallbacks
     def test_handle_set_hard_limit_reached(self):
@@ -637,13 +644,40 @@ class TestRedisResource(ResourceTestCaseBase, PersistenceMixin):
         reply = yield self.dispatch_command('set', key='bar', value='bar')
         self.check_reply(reply, success=False, reason='Too many keys')
         yield self.check_metric('bar', None, 100)
-        [limit_error] = self.api.logs
-        level, message = limit_error
-        self.assertEqual(level, logging.ERROR)
-        self.assertEqual(
-            message,
+        self.assert_api_log(
+            logging.ERROR,
             'Redis hard limit of test_id keys reached for sandbox 100. '
-            'No more keys can be written.')
+            'No more keys can be written.'
+        )
+
+    @inlineCallbacks
+    def test_keys_per_user_fallback_hard_limit(self):
+        yield self.create_resource({
+            'keys_per_user': 10,
+        })
+        yield self.create_metric('foo', 'a', total_count=10)
+        reply = yield self.dispatch_command('set', key='bar', value='bar')
+        self.check_reply(reply, success=False, reason='Too many keys')
+        self.assert_api_log(
+            logging.ERROR,
+            'Redis hard limit of test_id keys reached for sandbox 10. '
+            'No more keys can be written.'
+        )
+
+    @inlineCallbacks
+    def test_keys_per_user_fallback_soft_limit(self):
+        yield self.create_resource({
+            'keys_per_user': 10,
+        })
+        yield self.create_metric('foo', 'a', total_count=8)
+        reply = yield self.dispatch_command('set', key='bar', value='bar')
+        self.check_reply(reply, success=True)
+        self.assert_api_log(
+            logging.WARNING,
+            'Redis soft limit of 8 keys reached for sandbox test_id. '
+            'Once the hard limit of 10 is reached no more keys can '
+            'be written.'
+        )
 
     @inlineCallbacks
     def test_handle_get(self):


### PR DESCRIPTION
Currently it's a hard limit and everything grinds to a halt immediately, allowing no time for fixing.
