### PR TITLE
Fix sporadic failure in telnet tx tests

### DIFF
--- a/vumi/transports/telnet/tests/test_telnet.py
+++ b/vumi/transports/telnet/tests/test_telnet.py
@@ -167,18 +167,24 @@ class TelnetServerTransportTestCase(BaseTelnetServerTransortTestCase):
     @inlineCallbacks
     def test_transport_type_override(self):
         self.assertEqual(self.worker._transport_type, 'telnet')
+        # Clean up existing unused client.
+        self.client.transport.loseConnection()
+        [m_new, m_close] = yield self.wait_for_dispatched_messages(2)
+        self.assertEqual(m_new['transport_type'], 'telnet')
+        self.assertEqual(m_close['transport_type'], 'telnet')
+        self.clear_dispatched_messages()
+
         self.worker = yield self.get_transport({
             'telnet_port': 0,
             'transport_type': 'foo',
         })
         self.assertEqual(self.worker._transport_type, 'foo')
-        # Clean up existing unused client.
-        self.client.transport.loseConnection()
 
         self.client = yield self.make_client()
         yield self.wait_for_client_start()
         self.client.transport.write("foo\n")
-        [r1, r2, msg] = yield self.wait_for_dispatched_messages(3)
+        [m_new, msg] = yield self.wait_for_dispatched_messages(2)
+        self.assertEqual(m_new['transport_type'], 'foo')
         self.assertEqual(msg['transport_type'], 'foo')
 
 


### PR DESCRIPTION
We occasionally get tests failing like so:

```
Traceback (most recent call last):
  File "/Users/jerith/.virtualenvs/vumi/lib/python2.7/site-packages/twisted/internet/defer.py", line 1070, in _inlineCallbacks
    result = g.send(result)
  File "/Users/jerith/code/vumi/vumi/transports/telnet/tests/test_telnet.py", line 182, in test_transport_type_override
    self.assertEqual(msg['transport_type'], 'foo')
  File "/Users/jerith/.virtualenvs/vumi/lib/python2.7/site-packages/twisted/trial/_synctest.py", line 356, in assertEqual
    % (msg, pformat(first), pformat(second)))
twisted.trial.unittest.FailTest: not equal:
a = u'telnet'
b = 'foo'
```
