### PR TITLE
We need to be able to specify a non-default data_coding value for submit_sm

### DIFF
--- a/vumi/transports/smpp/tests/test_smpp.py
+++ b/vumi/transports/smpp/tests/test_smpp.py
@@ -539,7 +539,7 @@ class EsmeToSmscTestCase(TransportTestCase):
     def test_submit_sm_data_coding(self):
         # Startup
         yield self.startTransport()
-        self.transport.submit_sm_data_coding = 0
+        self.transport.submit_sm_data_coding = 8
         yield self.transport._block_till_bind
         yield self.clear_link_pdus()
 
@@ -559,7 +559,7 @@ class EsmeToSmscTestCase(TransportTestCase):
 
         submit_sm_pdu = yield pdu_queue.get()
         sms = submit_sm_pdu['pdu']['body']['mandatory_parameters']
-        self.assertEqual(sms['data_coding'], 0)
+        self.assertEqual(sms['data_coding'], 8)
 
     @inlineCallbacks
     def test_submit_and_deliver_ussd_continue(self):

--- a/vumi/transports/smpp/transport.py
+++ b/vumi/transports/smpp/transport.py
@@ -84,7 +84,7 @@ class SmppTransportConfig(Transport.CONFIG_CLASS):
         default='utf-8')
     submit_sm_data_coding = ConfigInt(
         'What data_coding value to tell the SMSC we\'re using when putting'
-        'an SMS on the wire', static=True, default=8)
+        'an SMS on the wire', static=True, default=0)
     data_coding_overrides = ConfigDict(
         "Overrides for data_coding character set mapping. This is useful for "
         "setting the default encoding (0), adding additional undefined "


### PR DESCRIPTION
We default to `0` and have no way of changing that.
