### PR TITLE
SMPP needs an option to force long messages.

### DIFF
--- a/vumi/transports/smpp/clientserver/client.py
+++ b/vumi/transports/smpp/clientserver/client.py
@@ -467,7 +467,8 @@ class EsmeTransceiver(Protocol):
                             kwargs.get('session_info', None))
 
         message = pdu_params['short_message']
-        if self.config.send_long_messages and len(message) > 254:
+        if self.config.send_long_messages and (
+            len(message) > 254 or self.config.force_long_messages):
             pdu.add_message_payload(''.join('%02x' % ord(c) for c in message))
 
         self.send_pdu(pdu)

--- a/vumi/transports/smpp/transport.py
+++ b/vumi/transports/smpp/transport.py
@@ -97,6 +97,11 @@ class SmppTransportConfig(Transport.CONFIG_CLASS):
         "`message_payload` optional field instead of the `short_message` "
         "field. Default is `False`, simply because that maintains previous "
         "behaviour.", default=False, static=True)
+    force_long_messages = ConfigBool(
+        "If `True`, all messages will be sent in the `message_payload` "
+        "optional field instead of the `short_message` field. "
+        "Default is `False`, simply because that maintains previous "
+        "behaviour.", default=False, static=True)
     split_bind_prefix = ConfigText(
         "This is the Redis prefix to use for storing things like sequence "
         "numbers and message ids for delivery report handling. It defaults "


### PR DESCRIPTION
This came up in Libya, some combination of SMSC + character encodings only allow for messages to be delivered if they're submitted as long messages.
