### PR TITLE
SMPP transport doesn't pause consumers when the connection is lost

### DIFF
--- a/vumi/transports/smpp/clientserver/client.py
+++ b/vumi/transports/smpp/clientserver/client.py
@@ -189,6 +189,7 @@ class EsmeTransceiver(Protocol):
         self.stop_enquire_link()
         self.cancel_drop_connection_call()
         log.msg('STATE: %s' % (self.state))
+        self.esme_callbacks.disconnect()
 
     def dataReceived(self, data):
         self.datastream += data
@@ -543,7 +544,6 @@ class EsmeTransceiverFactory(ClientFactory):
     @inlineCallbacks
     def clientConnectionLost(self, connector, reason):
         log.msg('Lost connection.  Reason:', reason)
-        yield self.esme_callbacks.disconnect()
         ClientFactory.clientConnectionLost(self, connector, reason)
 
     def clientConnectionFailed(self, connector, reason):

--- a/vumi/transports/smpp/transport.py
+++ b/vumi/transports/smpp/transport.py
@@ -228,7 +228,7 @@ class SmppTransport(Transport):
 
     def esme_disconnected(self):
         log.msg("ESME Disconnected")
-        self.pause_connectors()
+        return self.pause_connectors()
 
     # Redis message storing methods
 


### PR DESCRIPTION
This should be changed so we don't try to send messages over a connection that isn't bound.
