### PR TITLE
http_request_full doesn't cancel its timeout when a request succeeds

### DIFF
--- a/vumi/tests/test_utils.py
+++ b/vumi/tests/test_utils.py
@@ -187,7 +187,6 @@ class HttpUtilsTestCase(TestCase):
         self.assertEqual(request.delivered_body, "Yay")
         self.assertEqual(request.code, http.OK)
 
-
     @inlineCallbacks
     def test_http_request_full_drop(self):
         def interrupt(r):
@@ -276,6 +275,15 @@ class HttpUtilsTestCase(TestCase):
 
         d.addBoth(check_response)
         yield d
+
+    @inlineCallbacks
+    def test_http_request_full_ok_with_timeout_set(self):
+        # If we don't cancel the pending timeout check this test will fail with
+        # a dirty reactor.
+        self.set_render(lambda r: "Yay")
+        request = yield http_request_full(self.url, '', timeout=100)
+        self.assertEqual(request.delivered_body, "Yay")
+        self.assertEqual(request.code, http.OK)
 
     @inlineCallbacks
     def test_http_request_full_timeout_before_connect(self):

--- a/vumi/utils.py
+++ b/vumi/utils.py
@@ -140,8 +140,14 @@ def http_request_full(url, data=None, headers={}, method='POST',
             cancelling_on_timeout[0] = True
             d.cancel()
 
+        def cancel_timeout(r, delayed_call):
+            if delayed_call.active():
+                delayed_call.cancel()
+            return r
+
         d.addErrback(raise_timeout)
-        reactor.callLater(timeout, cancel_on_timeout)
+        delayed_call = reactor.callLater(timeout, cancel_on_timeout)
+        d.addCallback(cancel_timeout, delayed_call)
 
     return d
 


### PR DESCRIPTION
This causes problems elsewhere.
