### PR TITLE
Fix fake_amqp dirty reactor races in tests

### DIFF
--- a/vumi/blinkenlights/tests/test_metrics.py
+++ b/vumi/blinkenlights/tests/test_metrics.py
@@ -74,6 +74,7 @@ class TestMetricManager(TestCase):
     def test_start(self):
         channel = yield get_stubbed_channel()
         broker = channel.broker
+        self.addCleanup(broker.wait_delivery)
         mm = metrics.MetricManager("vumi.test.", 0.1, self.on_publish)
         cnt = mm.register(metrics.Count("my.count"))
         mm.start(channel)
@@ -101,6 +102,7 @@ class TestMetricManager(TestCase):
     def test_in_worker(self):
         worker = get_stubbed_worker(Worker)
         broker = worker._amqp_client.broker
+        self.addCleanup(broker.wait_delivery)
         mm = yield worker.start_publisher(metrics.MetricManager,
                                           "vumi.test.", 0.1, self.on_publish)
         acc = mm.register(metrics.Metric("my.acc"))

--- a/vumi/blinkenlights/tests/test_metrics_workers.py
+++ b/vumi/blinkenlights/tests/test_metrics_workers.py
@@ -37,6 +37,7 @@ class TestMetricTimeBucket(TestCase):
         worker = get_stubbed_worker(metrics_workers.MetricTimeBucket,
                                     config=config)
         broker = BrokerWrapper(worker._amqp_client.broker)
+        self.addCleanup(broker.wait_delivery)
         yield worker.startWorker()
 
         datapoints = [
@@ -90,6 +91,7 @@ class TestMetricAggregator(TestCase):
                                  config=config)
         worker._time = self.fake_time
         broker = BrokerWrapper(worker._amqp_client.broker)
+        self.addCleanup(broker.wait_delivery)
         yield worker.startWorker()
 
         datapoints = [
@@ -128,6 +130,7 @@ class TestMetricAggregator(TestCase):
                                  config=config)
         worker._time = self.fake_time
         broker = BrokerWrapper(worker._amqp_client.broker)
+        self.addCleanup(broker.wait_delivery)
         yield worker.startWorker()
 
         datapoints = [
@@ -166,6 +169,7 @@ class TestMetricAggregator(TestCase):
                                  config=config)
         worker._time = self.fake_time
         broker = BrokerWrapper(worker._amqp_client.broker)
+        self.addCleanup(broker.wait_delivery)
         yield worker.startWorker()
 
         datapoints = [
@@ -226,6 +230,7 @@ class TestAggregationSystem(TestCase):
     @inlineCallbacks
     def _setup_workers(self, bucketters, aggregators, bucket_size):
         broker = FakeAMQPBroker()
+        self.addCleanup(broker.wait_delivery)
         self.broker = BrokerWrapper(broker)
 
         bucket_config = {
@@ -282,6 +287,7 @@ class TestGraphitePublisher(TestCase):
     @inlineCallbacks
     def test_publish_metric(self):
         self.broker = FakeAMQPBroker()
+        self.addCleanup(self.broker.wait_delivery)
         datapoint = ("vumi.test.v1", 1.0, 1234)
         channel = yield get_stubbed_channel(self.broker)
         pub = metrics_workers.GraphitePublisher()
@@ -295,6 +301,7 @@ class TestGraphiteMetricsCollector(TestCase):
     def test_single_message(self):
         worker = get_stubbed_worker(metrics_workers.GraphiteMetricsCollector)
         broker = BrokerWrapper(worker._amqp_client.broker)
+        self.addCleanup(broker.wait_delivery)
         yield worker.startWorker()
 
         datapoints = [("vumi.test.foo", "", [(1234, 1.5)])]
@@ -327,6 +334,7 @@ class TestUDPMetricsCollector(TestCase):
                 'metrics_port': self.udp_server.getHost().port,
                 })
         self.broker = BrokerWrapper(self.worker._amqp_client.broker)
+        self.addCleanup(self.broker.wait_delivery)
         yield self.worker.startWorker()
 
     @inlineCallbacks
@@ -384,6 +392,7 @@ class TestRandomMetricsGenerator(TestCase):
         self._workers.append(worker)
         worker.on_run = self.on_run
         broker = BrokerWrapper(worker._amqp_client.broker)
+        self.addCleanup(broker.wait_delivery)
         yield worker.startWorker()
 
         yield self.wake_after_run()

--- a/vumi/demos/tests/test_words.py
+++ b/vumi/demos/tests/test_words.py
@@ -50,6 +50,7 @@ class TestSimpleAppWorker(unittest.TestCase):
 
     @inlineCallbacks
     def tearDown(self):
+        yield self.broker.wait_delivery()
         yield self.worker.stopWorker()
 
     @inlineCallbacks

--- a/vumi/dispatchers/simple/tests/test_dispatcher.py
+++ b/vumi/dispatchers/simple/tests/test_dispatcher.py
@@ -27,6 +27,7 @@ class TestTransport(TestCase):
 
     @inlineCallbacks
     def tearDown(self):
+        yield self.broker.wait_delivery()
         yield self.worker.stopWorker()
 
     @inlineCallbacks

--- a/vumi/tests/fake_amqp.py
+++ b/vumi/tests/fake_amqp.py
@@ -225,6 +225,10 @@ class FakeAMQPBroker(object):
         delivering any messages from the current run. This should not
         leave any messages undelivered, because basic_publish() kicks
         off a delivery run.
+
+        NOTE: This method should be called during test teardown to make
+        sure there are no pending delivery cleanups that will cause a
+        dirty reactor race.
         """
         if self._delivering is not None:
             return self._delivering['deferred']

--- a/vumi/tests/test_fake_amqp.py
+++ b/vumi/tests/test_fake_amqp.py
@@ -30,6 +30,9 @@ class FakeAMQPTestCase(TestCase):
     def setUp(self):
         self.broker = fake_amqp.FakeAMQPBroker()
 
+    def tearDown(self):
+        return self.broker.wait_delivery()
+
     def make_exchange(self, exchange, exchange_type):
         self.broker.exchange_declare(exchange, exchange_type)
         return self.broker.exchanges[exchange]

--- a/vumi/tests/utils.py
+++ b/vumi/tests/utils.py
@@ -489,6 +489,10 @@ class VumiWorkerTestCase(TestCase):
 
     @inlineCallbacks
     def tearDown(self):
+        # Wait for any pending message deliveries to avoid a race with a dirty
+        # reactor.
+        yield self._amqp.wait_delivery()
+        # Now stop all the workers.
         for worker in self._workers:
             yield worker.stopWorker()
 

--- a/vumi/transports/tests/test_failures.py
+++ b/vumi/transports/tests/test_failures.py
@@ -40,6 +40,7 @@ class FailureWorkerTestCase(unittest.TestCase, PersistenceMixin):
         self.redis = self.worker.redis
         yield self.redis._purge_all()  # Just in case
         self.broker = self.worker._amqp_client.broker
+        self.addCleanup(self.broker.wait_delivery)
 
     def assert_write_timestamp(self, expected, delta, now):
         self.assertEqual(expected,

--- a/vumi/transports/vas2nets/tests/test_failures.py
+++ b/vumi/transports/vas2nets/tests/test_failures.py
@@ -6,7 +6,7 @@ from twisted.web.resource import Resource
 from twisted.trial import unittest
 from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
 
-from vumi.message import TransportUserMessage, from_json
+from vumi.message import from_json
 from vumi.tests.utils import (
     get_stubbed_worker, TestResourceWorker, PersistenceMixin)
 from vumi.tests.fake_amqp import FakeAMQPBroker
@@ -84,6 +84,7 @@ class Vas2NetsFailureWorkerTestCase(unittest.TestCase, PersistenceMixin):
     def tearDown(self):
         for worker in self.workers:
             yield worker.stopWorker()
+        yield self.broker.wait_delivery()
         yield self._persist_tearDown()
 
     @inlineCallbacks


### PR DESCRIPTION
There are a lot of these, many of which are cause by pending delivery of messages that aren't directly dispatched from the test code. The solution is waiting for `FakeAMQPBroker.wait_delivery()` during teardown.
