### PR TITLE
Tracing Middleware

### DIFF
--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -1,4 +1,5 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.task import Clock
 
 from vumi.middleware.tracing import TracingMiddleware
 from vumi.application.tests.utils import ApplicationTestCase
@@ -10,6 +11,13 @@ class TracingMiddlewareTestCase(ApplicationTestCase):
     use_riak = False
     middleware_class = TracingMiddleware
     application_class = DummyApplicationWorker
+    clock = Clock()
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TracingMiddlewareTestCase, self).setUp()
+        self.patch(
+            TracingMiddleware, 'get_clock', lambda *a: self.clock)
 
     @inlineCallbacks
     def mk_mw(self, name):
@@ -24,5 +32,3 @@ class TracingMiddlewareTestCase(ApplicationTestCase):
     @inlineCallbacks
     def test_something(self):
         mw1 = yield self.mk_mw('app1')
-        print mw1.worker.transport_name
-        print mw1

--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -1,8 +1,7 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import Clock
 
-from vumi.middleware.tracing import (TracingMiddleware, msg_key,
-                                     TraceManager)
+from vumi.middleware.tracing import TracingMiddleware, TraceManager
 from vumi.application.tests.utils import ApplicationTestCase
 from vumi.application.tests.test_base import DummyApplicationWorker
 from vumi.tests.helpers import MessageHelper
@@ -135,7 +134,7 @@ class TracingMiddlewareTestCase(ApplicationTestCase):
             'content': 'hi there',
             'connector_name': 'default',
             'time': 0.0,
-            'message_type':'user_message',
+            'message_type': 'user_message',
             'message_id': mt['message_id'],
         })
         self.assertEqual(ack_hop, {

--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -1,13 +1,22 @@
+from twisted.internet.defer import inlineCallbacks
+
 from vumi.middleware.tracing import TracingMiddleware
-from vumi.tests.helpers import VumiTestCase
+from vumi.application.tests.utils import ApplicationTestCase
+from vumi.application.tests.test_base import DummyApplicationWorker
 
 
-class TracingMiddlewareTestCase(VumiTestCase):
+class TracingMiddlewareTestCase(ApplicationTestCase):
 
     use_riak = False
+    application_class = DummyApplicationWorker
 
+    @inlineCallbacks
     def setUp(self):
-        self.mw = TracingMiddleware("tracing", {}, object())
+        yield super(TracingMiddlewareTestCase, self).setUp()
+        dummy_worker = yield self.get_application({})
+        self.mw = TracingMiddleware(
+            "tracing", self.mk_config({}), dummy_worker)
+        yield self.mw.setup_middleware()
 
     def test_something(self):
         pass

--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -1,4 +1,4 @@
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.middleware.tracing import TracingMiddleware
 from vumi.application.tests.utils import ApplicationTestCase
@@ -8,15 +8,21 @@ from vumi.application.tests.test_base import DummyApplicationWorker
 class TracingMiddlewareTestCase(ApplicationTestCase):
 
     use_riak = False
+    middleware_class = TracingMiddleware
     application_class = DummyApplicationWorker
 
     @inlineCallbacks
-    def setUp(self):
-        yield super(TracingMiddlewareTestCase, self).setUp()
-        dummy_worker = yield self.get_application({})
-        self.mw = TracingMiddleware(
-            "tracing", self.mk_config({}), dummy_worker)
-        yield self.mw.setup_middleware()
+    def mk_mw(self, name):
+        app = yield self.get_application(self.mk_config({
+            'transport_name': '%s_transport' % (name,)
+        }))
+        mw = self.middleware_class(
+            '%s_middleware' % (name,), self.mk_config({}), app)
+        yield mw.setup_middleware()
+        returnValue(mw)
 
+    @inlineCallbacks
     def test_something(self):
-        pass
+        mw1 = yield self.mk_mw('app1')
+        print mw1.worker.transport_name
+        print mw1

--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -1,0 +1,13 @@
+from vumi.middleware.tracing import TracingMiddleware
+from vumi.tests.helpers import VumiTestCase
+
+
+class TracingMiddlewareTestCase(VumiTestCase):
+
+    use_riak = False
+
+    def setUp(self):
+        self.mw = TracingMiddleware("tracing", {}, object())
+
+    def test_something(self):
+        pass

--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -1,9 +1,10 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import Clock
 
-from vumi.middleware.tracing import TracingMiddleware
+from vumi.middleware.tracing import TracingMiddleware, msg_key
 from vumi.application.tests.utils import ApplicationTestCase
 from vumi.application.tests.test_base import DummyApplicationWorker
+from vumi.tests.helpers import MessageHelper
 
 
 class TracingMiddlewareTestCase(ApplicationTestCase):
@@ -18,6 +19,7 @@ class TracingMiddlewareTestCase(ApplicationTestCase):
         yield super(TracingMiddlewareTestCase, self).setUp()
         self.patch(
             TracingMiddleware, 'get_clock', lambda *a: self.clock)
+        self.msg_helper = MessageHelper()
 
     @inlineCallbacks
     def mk_mw(self, name):
@@ -30,5 +32,70 @@ class TracingMiddlewareTestCase(ApplicationTestCase):
         returnValue(mw)
 
     @inlineCallbacks
-    def test_something(self):
-        mw1 = yield self.mk_mw('app1')
+    def test_trace_mo_mt_reply(self):
+        mo = self.msg_helper.make_inbound('hello')
+        msisdn = mo['from_addr']
+        mt = self.msg_helper.make_reply(mo, 'hi there')
+        ack = self.msg_helper.make_ack(mt)
+        dr = self.msg_helper.make_delivery_report(mt)
+
+        mw = yield self.mk_mw('app1')
+        yield mw.handle_inbound(mo, 'default')
+        self.clock.advance(10)
+        yield mw.handle_outbound(mt, 'default')
+        self.clock.advance(1)
+        yield mw.handle_event(ack, 'default')
+        self.clock.advance(1)
+        mw.handle_event(dr, 'default')
+
+        mo_trace = yield mw.get_trace(mo['message_id'])
+        ttl = yield mw.redis.ttl(msg_key(mo['message_id']))
+        self.assertTrue(0 < ttl <= mw.config.lifetime)
+
+        # trace of the inbound message
+        [_mo, _mt] = mo_trace
+        self.assertEqual(_mo, {
+            'transport_name': 'app1_transport',
+            'direction': 'inbound',
+            'content': 'hello',
+            'connector_name': 'default',
+            'time': 0.0,
+            'message_type': 'user_message',
+            'message_id': mo['message_id'],
+        })
+        self.assertEqual(_mt, {
+            'transport_name': 'app1_transport',
+            'direction': 'outbound',
+            'content': 'hi there',
+            'reply_message_id': mt['message_id'],
+            'connector_name': 'default',
+            'time': 10.0,
+            'message_type': 'user_message',
+        })
+
+        mt_trace = yield mw.get_trace(mt['message_id'])
+        [_mt, _ack, _dr] = mt_trace
+        self.assertEqual(_mt, {
+            'transport_name': 'app1_transport',
+            'direction': 'outbound',
+            'content': 'hi there',
+            'connector_name': 'default',
+            'time': 10.0, 'message_type':
+            'user_message',
+            'message_id': mt['message_id'],
+        })
+        self.assertEqual(_ack, {
+            'event_id': ack['event_id'],
+            'transport_name': 'app1_transport',
+            'message_type': 'event',
+            'event_type': 'ack',
+            'time': 11.0,
+        })
+        self.assertEqual(_dr, {
+            'transport_name': 'app1_transport',
+            'event_type': 'delivery_report',
+            'event_id': dr['event_id'],
+            'time': 12.0,
+            'delivery_status': 'delivered',
+            'message_type': 'event',
+        })

--- a/vumi/middleware/tests/test_tracing.py
+++ b/vumi/middleware/tests/test_tracing.py
@@ -34,7 +34,6 @@ class TracingMiddlewareTestCase(ApplicationTestCase):
     @inlineCallbacks
     def test_trace_mo_mt_reply(self):
         mo = self.msg_helper.make_inbound('hello')
-        msisdn = mo['from_addr']
         mt = self.msg_helper.make_reply(mo, 'hi there')
         ack = self.msg_helper.make_ack(mt)
         dr = self.msg_helper.make_delivery_report(mt)

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -1,10 +1,12 @@
 # -*- test-case-name: vumi.middleware.tests.test_tracing -*-
+import time
+import json
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet import reactor
 
 from vumi.persist.txredis_manager import TxRedisManager
-from vumi.config import Config, ConfigDict
+from vumi.config import Config, ConfigDict, ConfigInt
 from vumi.middleware.base import BaseMiddleware
 
 
@@ -21,6 +23,12 @@ class BaseMiddlewareWithConfig(BaseMiddleware):
 class TracingMiddlewareConfig(BaseMiddlewareWithConfig.CONFIG_CLASS):
 
     redis_manager = ConfigDict("Redis Config", static=True)
+    lifetime = ConfigInt('How long to keep a trace for in seconds',
+                         static=True, default=600)
+
+
+def msg_key(message_id):
+    return ':'.join(['trace', message_id])
 
 
 class TracingMiddleware(BaseMiddlewareWithConfig):
@@ -35,6 +43,8 @@ class TracingMiddleware(BaseMiddlewareWithConfig):
     def setup_middleware(self):
         self.redis = yield TxRedisManager.from_config(
             self.config.redis_manager)
+        self.transport_name = self.worker.transport_name
+        self.clock = self.get_clock()
 
     def get_clock(self):
         return self.clock
@@ -42,11 +52,65 @@ class TracingMiddleware(BaseMiddlewareWithConfig):
     def teardown_middleware(self):
         return self.redis.close()
 
+    def store_hop(self, message_id, data):
+        data.setdefault('time', self.clock.seconds())
+        data.setdefault('transport_name', self.transport_name)
+        key = msg_key(message_id)
+        d = self.redis.rpush(key, json.dumps(data))
+        d.addCallback(lambda _: self.redis.expire(key, self.config.lifetime))
+        return d
+
+    def store_msg_hop(self, message, connector_name, direction):
+        d = self.store_hop(message['message_id'], {
+            'message_id': message['message_id'],
+            'message_type': message['message_type'],
+            'direction': direction,
+            'connector_name': connector_name,
+            'content': message['content'],
+        })
+        d.addCallback(lambda _: message)
+        return d
+
+    def store_event_hop(self, event, connector_name):
+        data = {
+            'message_type': event['message_type'],
+            'event_id': event['event_id'],
+            'event_type': event['event_type'],
+        }
+
+        if data['event_type'] == 'nack':
+            data['nack_reason'] = event['nack_reason']
+        elif data['event_type'] == 'delivery_report':
+            data['delivery_status'] = event['delivery_status']
+
+        d = self.store_hop(event['user_message_id'], data)
+        d.addCallback(lambda _: event)
+        return d
+
     def handle_inbound(self, message, connector_name):
-        pass
+        return self.store_msg_hop(message, connector_name, 'inbound')
 
     def handle_outbound(self, message, connector_name):
-        pass
+        d = self.store_msg_hop(message, connector_name, 'outbound')
+        d.addCallback(self._link_reply, connector_name)
+        return d
+
+    def _link_reply(self, message, connector_name):
+        in_reply_to = message.get('in_reply_to')
+        if in_reply_to is not None:
+            return self.store_hop(in_reply_to, {
+                'message_type': message['message_type'],
+                'direction': 'outbound',
+                'connector_name': connector_name,
+                'reply_message_id': message['message_id'],
+                'content': message['content'],
+            })
+        return message
 
     def handle_event(self, message, connector_name):
-        pass
+        return self.store_event_hop(message, connector_name)
+
+    def get_trace(self, message_id):
+        d = self.redis.lrange(msg_key(message_id), 0, 10)
+        d.addCallback(lambda hops: [json.loads(hop) for hop in hops])
+        return d

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -31,6 +31,17 @@ def msg_key(message_id):
     return ':'.join(['trace', message_id])
 
 
+class TraceManager(object):
+
+    def __init__(self, redis):
+        self.redis = redis
+
+    def get_trace(self, message_id):
+        d = self.redis.lrange(msg_key(message_id), 0, 10)
+        d.addCallback(lambda hops: [json.loads(hop) for hop in hops])
+        return d
+
+
 class TracingMiddleware(BaseMiddlewareWithConfig):
     """
     Middleware for tracing all the hops and associated timestamps
@@ -109,8 +120,3 @@ class TracingMiddleware(BaseMiddlewareWithConfig):
 
     def handle_event(self, message, connector_name):
         return self.store_event_hop(message, connector_name)
-
-    def get_trace(self, message_id):
-        d = self.redis.lrange(msg_key(message_id), 0, 10)
-        d.addCallback(lambda hops: [json.loads(hop) for hop in hops])
-        return d

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -1,6 +1,7 @@
 # -*- test-case-name: vumi.middleware.tests.test_tracing -*-
 
 from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet import reactor
 
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.config import Config, ConfigDict
@@ -28,11 +29,15 @@ class TracingMiddleware(BaseMiddlewareWithConfig):
     a message took when being routed through the system
     """
     CONFIG_CLASS = TracingMiddlewareConfig
+    clock = reactor
 
     @inlineCallbacks
     def setup_middleware(self):
         self.redis = yield TxRedisManager.from_config(
             self.config.redis_manager)
+
+    def get_clock(self):
+        return self.clock
 
     def teardown_middleware(self):
         return self.redis.close()

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -1,5 +1,4 @@
 # -*- test-case-name: vumi.middleware.tests.test_tracing -*-
-import time
 import json
 
 from twisted.internet.defer import inlineCallbacks

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -35,7 +35,7 @@ class TracingMiddleware(BaseMiddlewareWithConfig):
             self.config.redis_manager)
 
     def teardown_middleware(self):
-        pass
+        return self.redis.close()
 
     def handle_inbound(self, message, connector_name):
         pass

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -2,17 +2,37 @@
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
+from vumi.persist.txredis_manager import TxRedisManager
+from vumi.config import Config, ConfigDict
 from vumi.middleware.base import BaseMiddleware
 
 
-class TracingMiddleware(BaseMiddleware):
+class BaseMiddlewareWithConfig(BaseMiddleware):
+
+    CONFIG_CLASS = Config
+
+    def __init__(self, name, config, worker):
+        self.name = name
+        self.config = self.CONFIG_CLASS(config, static=True)
+        self.worker = worker
+
+
+class TracingMiddlewareConfig(BaseMiddlewareWithConfig.CONFIG_CLASS):
+
+    redis_manager = ConfigDict("Redis Config", static=True)
+
+
+class TracingMiddleware(BaseMiddlewareWithConfig):
     """
     Middleware for tracing all the hops and associated timestamps
     a message took when being routed through the system
     """
+    CONFIG_CLASS = TracingMiddlewareConfig
 
+    @inlineCallbacks
     def setup_middleware(self):
-        pass
+        self.redis = yield TxRedisManager.from_config(
+            self.config.redis_manager)
 
     def teardown_middleware(self):
         pass

--- a/vumi/middleware/tracing.py
+++ b/vumi/middleware/tracing.py
@@ -1,0 +1,27 @@
+# -*- test-case-name: vumi.middleware.tests.test_tracing -*-
+
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+from vumi.middleware.base import BaseMiddleware
+
+
+class TracingMiddleware(BaseMiddleware):
+    """
+    Middleware for tracing all the hops and associated timestamps
+    a message took when being routed through the system
+    """
+
+    def setup_middleware(self):
+        pass
+
+    def teardown_middleware(self):
+        pass
+
+    def handle_inbound(self, message, connector_name):
+        pass
+
+    def handle_outbound(self, message, connector_name):
+        pass
+
+    def handle_event(self, message, connector_name):
+        pass


### PR DESCRIPTION
**not ready for review yet**

Every so often we get a support request to track a specific from_address / to_address in the system. Currently this results in grepping over log files and with `n` servers this becomes more painful<sup>n</sup>.

A tracing middleware that tracks for the latest `n` number of msisdns what time it was seen at what worker and on what connector would allow us to track both the route a message took but also the average time it took for each hop through the network.
