### PR TITLE
Ensure vagrant uses a local box if installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure("2") do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
+  config.vm.box = "precise64.box"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   # Create a forwarded port mapping which allows access to a specific port


### PR DESCRIPTION
Without config.vm.box , vagrant up will always try and download the base box. Even if you have it locally. Small change so it will use a local box if available. 
