### PR TITLE
ConfigClassName field for vumi.config needs to allow for zope.interface checks.

### DIFF
--- a/vumi/config.py
+++ b/vumi/config.py
@@ -194,12 +194,22 @@ class ConfigRegex(ConfigText):
 class ConfigClassName(ConfigText):
     field_type = 'Class'
 
+    def __init__(self, doc, required=False, default=None, static=False,
+                 implements=None):
+        super(ConfigClassName, self).__init__(doc, required, default, static)
+        self.interface = implements
+
     def clean(self, value):
         try:
-            return load_class_by_string(value)
+            cls = load_class_by_string(value)
         except (ValueError, ImportError), e:
             # ValueError for empty module name
             self.raise_config_error(str(e))
+
+        if self.interface and not self.interface.implementedBy(cls):
+            self.raise_config_error('does not implement %r.' % (
+                self.interface,))
+        return cls
 
 
 class ConfigServerEndpoint(ConfigText):

--- a/vumi/tests/test_config.py
+++ b/vumi/tests/test_config.py
@@ -7,6 +7,21 @@ from vumi.config import (
     ConfigClientEndpoint, ConfigClassName)
 from vumi.tests.helpers import VumiTestCase
 
+from zope.interface import Interface, implements
+
+
+class ITestConfigInterface(Interface):
+
+    def implements_this(foo):
+        """This should be implemented"""
+
+
+class TestConfigClassName(object):
+    implements(ITestConfigInterface)
+
+    def implements_this(self, foo):
+        pass
+
 
 class ConfigTest(VumiTestCase):
     def test_simple_config(self):
@@ -217,13 +232,27 @@ class ConfigFieldTest(VumiTestCase):
 
     def test_classname_field(self):
         field = self.make_field(ConfigClassName)
-        klass = self.field_value(field, 'vumi.tests.test_config.ConfigTest')
-        self.assertEqual(klass, ConfigTest)
+        klass = self.field_value(field,
+                                 'vumi.tests.test_config.TestConfigClassName')
+        self.assertEqual(klass, TestConfigClassName)
 
     def test_invalid_classname_field(self):
         field = self.make_field(ConfigClassName)
         self.assert_field_invalid(field, '0000')
         self.assert_field_invalid(field, '0000.bar')
+
+    def test_classname_implements_field(self):
+        field = self.make_field(ConfigClassName,
+                                implements=ITestConfigInterface)
+        klass = self.field_value(
+            field, 'vumi.tests.test_config.TestConfigClassName')
+        self.assertEqual(klass, TestConfigClassName)
+
+    def test_invalid_classname_implements_field(self):
+        field = self.make_field(ConfigClassName,
+                                implements=ITestConfigInterface)
+        self.assert_field_invalid(
+            field, 'vumi.tests.test_config.ConfigTest')
 
     def test_int_field(self):
         field = self.make_field(ConfigInt)


### PR DESCRIPTION
If given an `implements` keyword argument the `ConfigClassName` should check whether the class pointed at [implements](http://docs.zope.org/zope.interface/api.html#ISpecification.implementedBy) a specific `zope.interface.Interface`.

This was suggested by @hodgestar in the review of #677
