### PR TITLE
Sort out requirements and setup.py

### DIFF
--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -3,3 +3,5 @@ coverage
 python-subunit
 junitxml
 pep8
+pyflakes
+supervisor

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,18 +1,2 @@
-zope.interface
-Twisted
-# txAMQP prior to 0.5 does not support modern rabbitMQ versions.
-txAMQP>=0.5
-PyYAML
-iso8601
-supervisor
-pyOpenSSL
-python-ssmi>=0.0.5
-wokkel
-redis
-txredis
-python-smpp>=0.1.1
-pytz==2013b
-riakasaurus>=1.1.1
-riak==1.5.2
-txJSON-RPC==0.3.1
-txTwitter>=0.1.0a
+# Our dependencies are all specified in setup.py.
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,5 @@
 from setuptools import setup, find_packages
-import re
 
-
-def listify(filename):
-    return filter(None, open(filename, 'r').read().split('\n'))
-
-
-_SIMPLE_VERSION_RE = re.compile("(?P<name>.*)-(?P<version>[0-9.]+)$")
-
-
-def parse_requirements(filename):
-    install_requires = []
-    dependency_links = []
-    for requirement in listify(filename):
-        if requirement.startswith("https:") or requirement.startswith("http:"):
-            (_, _, name) = requirement.partition('#egg=')
-            ver_match = _SIMPLE_VERSION_RE.match(name)
-            if ver_match:
-                # egg names with versions need to be converted to
-                # an == requirement.
-                name = "%(name)s==%(version)s" % ver_match.groupdict()
-            install_requires.append(name)
-            dependency_links.append(requirement)
-        else:
-            install_requires.append(requirement)
-    return install_requires, dependency_links
-
-install_requires, dependency_links = parse_requirements("requirements.pip")
 
 setup(
     name="vumi",
@@ -40,14 +13,28 @@ setup(
     author='Praekelt Foundation',
     author_email='dev@praekeltfoundation.org',
     packages=find_packages() + [
-        # NOTE:2012-01-18: This is commented out for now, pending a fix for
-        # https://github.com/pypa/pip/issues/355
-        #'twisted.plugins',
+        'twisted.plugins',
     ],
     package_data={'twisted.plugins': ['twisted/plugins/*.py']},
     include_package_data=True,
-    install_requires=install_requires,
-    dependency_links=dependency_links,
+    install_requires=[
+        'zope.interface',
+        'Twisted>=12.0.0',
+        'txAMQP>=0.5',
+        'PyYAML',
+        'iso8601',
+        'pyOpenSSL',
+        'python-ssmi>=0.0.5',
+        'wokkel',
+        'redis',
+        'txredis',
+        'python-smpp>=0.1.1',
+        'pytz==2013b',
+        'riakasaurus>=1.1.1',
+        'riak==1.5.2',
+        'txJSON-RPC==0.3.1',
+        'txTwitter>=0.1.0a',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
We really should do something more like https://caremad.io/blog/setup-vs-requirement/ instead of trying to parse `requirements.pip` in `setup.py`.

We should also use http://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies for some of our transport-specific deps.
