### PR TITLE
Reject RapidSMS messages with invalid to_addr values

### DIFF
--- a/vumi/application/rapidsms_relay.py
+++ b/vumi/application/rapidsms_relay.py
@@ -284,6 +284,9 @@ class RapidSMSRelay(ApplicationWorker):
         data = json.loads(request.content.read())
         content = data['content']
         to_addrs = data['to_addr']
+        if not isinstance(to_addrs, list):
+            raise BadRequestError(
+                "Supplied `to_addr` (%r) was not a list." % (to_addrs,))
         in_reply_to = data.get('in_reply_to')
         endpoint = data.get('endpoint')
         if in_reply_to is not None:

--- a/vumi/application/tests/test_rapidsms_relay.py
+++ b/vumi/application/tests/test_rapidsms_relay.py
@@ -272,3 +272,17 @@ class TestRapidSMSRelay(VumiTestCase):
                          "Endpoint u'bar' not defined in list of allowed"
                          " endpoints ['default', '10010', '10020']")
         [err] = self.flushLoggedErrors(BadRequestError)
+
+    @inlineCallbacks
+    def test_rapidsms_relay_outbound_on_invalid_to_addr(self):
+        yield self.setup_resource()
+        response = yield self._call_relay({
+            'to_addr': '+123456',
+            'content': u'foo',
+            'endpoint': u'bar',
+        })
+        self.assertEqual([], self.app_helper.get_dispatched_outbound())
+        self.assertEqual(response.code, 400)
+        self.assertEqual(response.delivered_body,
+                         "Supplied `to_addr` (u'+123456') was not a list.")
+        [err] = self.flushLoggedErrors(BadRequestError)


### PR DESCRIPTION
The UReport wrapper around the RapidSMS Vumi backend accidentally sends the to_addr as a space-separate string of to-addresses and sending a message to each character in the to_addr is not a great idea.
