### PR TITLE
UDH sending fails when sequence numbers go over 256.

### DIFF
--- a/vumi/transports/smpp/protocol.py
+++ b/vumi/transports/smpp/protocol.py
@@ -545,7 +545,8 @@ class EsmeTransceiver(Protocol):
         for i, msg in enumerate(split_msg):
             pdu_params = pdu_params.copy()
             optional_parameters.update({
-                'sar_msg_ref_num': ref_num,
+                # Reference number must be between 00 & FFFF
+                'sar_msg_ref_num': (ref_num % 0xFFFF),
                 'sar_total_segments': len(split_msg),
                 'sar_segment_seqnum': i + 1,
             })
@@ -595,7 +596,8 @@ class EsmeTransceiver(Protocol):
                 '\05',  # Full UDH header length
                 '\00',  # Information Element Identifier for Concatenated SMS
                 '\03',  # header length
-                chr(ref_num),
+                # Reference number must be between 00 & FF
+                chr(ref_num % 0xFF),
                 chr(len(split_msg)),
                 chr(i + 1),
             ])


### PR DESCRIPTION
doh.

```
2014-01-24 06:10:37+0000 [WorkerAMQClient,client] Processed outbound message for ambient_go_smpp_transport: {"transport_name": "ambient_go_smpp_transport", "transport_metadata": {}, "group": null, "from_addr": null, "timestamp": "2014-01-24 06:10:36.809068", "to_addr": "XXXXXXXX", "content": "Siamusamba K sold 62 Boxes(s) of Tomato for 5890.00 (95.00 per Boxes)", "routing_metadata": {"go_hops": [[["CONVERSATION:http_api:6416f30f12164482a9462c12776d6476", "default"], ["TRANSPORT_TAG:longcode:default10223", "default"]]], "endpoint_name": "default"}, "message_version": "20110921", "transport_type": "sms", "helper_metadata": {"go": {"conversation_type": "http_api", "user_account": "9a5fe5ba1a764e499beeab0497163029", "conversation_key": "6416f30f12164482a9462c12776d6476"}, "tag": {"tag": ["longcode", "default10223"]}}, "in_reply_to": null, "session_event": null, "message_id": "e75e34541474464aa6cdfd561580c0d6", "message_type": "user_message"}
2014-01-24 06:10:37+0000 [VumiRedis,client] Unhandled Error
        Traceback (most recent call last):
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 382, in callback
            self._startRunCallbacks(result)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 490, in _startRunCallbacks
            self._runCallbacks()
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1155, in gotResult
            _inlineCallbacks(r, g, deferred)
        --- <exception caught here> ---
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
            result = g.send(result)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/transports/smpp/protocol.py", line 598, in submit_csm_udh
            chr(ref_num),
        exceptions.ValueError: chr() arg not in range(256)
```
