### PR TITLE
USSD transports unhappy after a disconnect.

### DIFF
--- a/vumi/transports/truteq/truteq.py
+++ b/vumi/transports/truteq/truteq.py
@@ -44,7 +44,7 @@ class TruteqTransportProtocol(SSMIProtocol):
 
     def connectionMade(self):
         config = self.factory.vumi_transport.get_static_config()
-        self.factory.protocol = self
+        self.factory.protocol_instance = self
         self.noisy = config.debug
         d = self.authenticate(config.username, config.password)
         d.addCallback(
@@ -177,7 +177,7 @@ class TruteqTransport(Transport):
             })
 
     def handle_outbound_message(self, message):
-        protocol = self.client_factory.protocol
+        protocol = self.client_factory.protocol_instance
         text = message.get('content') or ''
 
         # Truteq uses \r as a message delimiter in the protocol.


### PR DESCRIPTION
```
2014-02-01 10:19:08+0000 [Uninitialized] Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/log.py", line 88, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/log.py", line 73, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 619, in _doReadOrWrite
            why = selectable.doWrite()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 593, in doConnect
            self._connectDone()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 612, in _connectDone
            self.protocol.makeConnection(self)
        exceptions.AttributeError: 'NoneType' object has no attribute 'makeConnection'

2014-02-01 10:19:08+0000 [Uninitialized] Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/application/app.py", line 313, in runReactorWithLogging
            reactor.run()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1192, in run
            self.mainLoop()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1204, in mainLoop
            self.doIteration(t)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/epollreactor.py", line 396, in doPoll
            log.callWithLogger(selectable, _drdw, selectable, fd, event)
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/log.py", line 88, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/log.py", line 73, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 627, in _doReadOrWrite
            self._disconnectSelectable(selectable, why, inRead)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 263, in _disconnectSelectable
            selectable.connectionLost(failure.Failure(why))
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 485, in connectionLost
            self._commonConnection.connectionLost(self, reason)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 299, in connectionLost
            protocol.connectionLost(reason)
            exceptions.AttributeError: 'NoneType' object has no attribute 'connectionLost'

```
