### PR TITLE
SMPP transport is missing a yield when asking for the protocol while disconnecting.

### DIFF
--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -107,14 +107,12 @@ class SmppService(ReconnectingClientService):
             self.wait_on_protocol_deferreds.append(d)
             return d
 
+    @inlineCallbacks
     def stopService(self):
         protocol = yield self.get_protocol()
         if protocol is not None:
-            d = protocol.disconnect()
-            d.addCallback(
-                lambda _: ReconnectingClientService.stopService(self))
-            return d
-        return ReconnectingClientService.stopService(self)
+            yield protocol.disconnect()
+        returnValue(ReconnectingClientService.stopService(self))
 
 
 class SmppTransceiverTransport(Transport):

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -108,7 +108,7 @@ class SmppService(ReconnectingClientService):
             return d
 
     def stopService(self):
-        protocol = self.get_protocol()
+        protocol = yield self.get_protocol()
         if protocol is not None:
             d = protocol.disconnect()
             d.addCallback(


### PR DESCRIPTION
```
2014-02-10 08:12:05+0000 [-] Unhandled Error
        Traceback (most recent call last):
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 295, in addCallbacks
            self._runCallbacks()
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/transports/base.py", line 74, in <lambda>
            d.addCallback(lambda r: self.teardown_transport())
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1237, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/mnt/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
            result = g.send(result)
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/transports/smpp/smpp_transport.py", line 161, in teardown_transport
            yield self.service.stopService()
          File "/mnt/praekelt/vumi-go/ve/src/vumi/vumi/transports/smpp/smpp_transport.py", line 113, in stopService
            d = protocol.disconnect()
        exceptions.AttributeError: Deferred instance has no attribute 'disconnect'
```
