### PR TITLE
Better disconnection tracking in tests

### DIFF
--- a/vumi/demos/tests/test_hangman.py
+++ b/vumi/demos/tests/test_hangman.py
@@ -6,7 +6,6 @@ import string
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet import reactor
-from twisted.web.server import Site
 from twisted.web.resource import Resource
 from twisted.web.static import Data
 
@@ -14,6 +13,7 @@ from vumi.demos.hangman import HangmanGame, HangmanWorker
 from vumi.message import TransportUserMessage
 from vumi.application.tests.helpers import ApplicationHelper
 from vumi.tests.helpers import VumiTestCase
+from vumi.utils import LogFilterSite
 
 
 def mkstate(word, guesses, msg):
@@ -146,7 +146,8 @@ class TestHangmanWorker(VumiTestCase):
         # data is elephant with a UTF-8 encoded BOM
         # it is a sad elephant (as seen in the wild)
         root.putChild("word", Data('\xef\xbb\xbfelephant\r\n', 'text/html'))
-        site_factory = Site(root)
+        site_factory = LogFilterSite(root)
+        self.add_cleanup(site_factory.disconnect_tracker.wait)
         self.webserver = yield reactor.listenTCP(
             0, site_factory, interface='127.0.0.1')
         addr = self.webserver.getHost()

--- a/vumi/tests/test_utils.py
+++ b/vumi/tests/test_utils.py
@@ -122,7 +122,8 @@ class TestHttpUtils(VumiTestCase):
     def setUp(self):
         self.root = Resource()
         self.root.isLeaf = True
-        site_factory = Site(self.root)
+        site_factory = LogFilterSite(self.root)
+        self.add_cleanup(site_factory.disconnect_tracker.wait)
         self.webserver = yield reactor.listenTCP(
             0, site_factory, interface='127.0.0.1')
         # This is a lambda because we replace self.webserver in a test.

--- a/vumi/tests/utils.py
+++ b/vumi/tests/utils.py
@@ -170,9 +170,9 @@ class MockHttpServer(object):
     @inlineCallbacks
     def start(self):
         root = MockResource(self._handler)
-        site_factory = LogFilterSite(root)
+        self._site_factory = LogFilterSite(root)
         self._webserver = yield reactor.listenTCP(
-            0, site_factory, interface='127.0.0.1')
+            0, self._site_factory, interface='127.0.0.1')
         self.addr = self._webserver.getHost()
         self.url = "http://%s:%s/" % (self.addr.host, self.addr.port)
 
@@ -180,6 +180,7 @@ class MockHttpServer(object):
     def stop(self):
         yield self._webserver.stopListening()
         yield self._webserver.loseConnection()
+        yield self._site_factory.disconnect_tracker.wait()
 
 
 def maybe_async(sync_attr):

--- a/vumi/transports/integrat/tests/test_integrat.py
+++ b/vumi/transports/integrat/tests/test_integrat.py
@@ -2,9 +2,8 @@
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
-from twisted.web.server import Site
 
-from vumi.utils import http_request
+from vumi.utils import LogFilterSite, http_request
 from vumi.tests.utils import MockHttpServer
 from vumi.message import TransportUserMessage
 from vumi.transports.integrat.integrat import (IntegratHttpResource,
@@ -47,8 +46,9 @@ class TestIntegratHttpResource(VumiTestCase):
     @inlineCallbacks
     def setUp(self):
         self.msgs = []
-        site_factory = Site(IntegratHttpResource("testgrat", "ussd",
-            self._publish))
+        site_factory = LogFilterSite(
+            IntegratHttpResource("testgrat", "ussd", self._publish))
+        self.add_cleanup(site_factory.disconnect_tracker.wait)
         self.server = yield reactor.listenTCP(
             0, site_factory, interface='127.0.0.1')
         self.add_cleanup(self.server.loseConnection)


### PR DESCRIPTION
We're seeing lots of random test failures caused by connections that haven't been completely closed by the time the test cleanup returns.
