### PR TITLE
Handle concurrent redis QUITs

### DIFF
--- a/vumi/persist/txredis_manager.py
+++ b/vumi/persist/txredis_manager.py
@@ -56,12 +56,11 @@ class VumiRedis(txr.Redis):
         anything useful about that here.
         """
         self.factory.stopTrying()
+        d = succeed(None)
         if not self._client_shutdown_called:
             self._client_shutdown_called = True
-            # We don't wait for the response here because we don't care what it
-            # is. Instead, we wait for the server to disconnect us.
-            self.quit()
-        return self._disconnected_d
+            d.addCallback(lambda _: self.quit())
+        return d.addCallback(lambda _: self._disconnected_d)
 
     def hget(self, key, field):
         d = super(VumiRedis, self).hget(key, field)


### PR DESCRIPTION
Many of our random test failures are `Failure: twisted.internet.error.ConnectionLost: Connection to the other side was lost in a non-clean fashion.`

I suspect this is caused by multiple Redis managers sharing a connection and sending their `QUIT` commands at more or less the same time. If a command is sent after a `QUIT` has been issued but before the server closes the socket, we could be disconnected while the client still has data in the send buffer which will result in the aforementioned exception.

The solution is twofold:
1. We need to wait for `connectionLost` before returning from `TxRedisManager._close()` so that we're sure the connection is completely closed.
2. We need to avoid sending multiple `QUIT` commands to a single connection.

Even if this turns out not to solve the test problems, cleaner shutdown is a good thing in general.
