### PR TITLE
SSL.SSLv23_METHOD is broken on Ubuntu

### DIFF
--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -20,7 +20,8 @@ from twisted.python.failure import Failure
 from twisted.web.client import WebClientContextFactory
 
 from OpenSSL.SSL import (
-    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_CLIENT_ONCE, VERIFY_NONE)
+    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_CLIENT_ONCE, VERIFY_NONE,
+    SSLv3_METHOD, SSLv23_METHOD, TLSv1_METHOD)
 
 from vumi.config import ConfigText, ConfigInt, ConfigList, ConfigDict
 from vumi.application.base import ApplicationWorker
@@ -708,8 +709,10 @@ class LoggingResource(SandboxResource):
 
 class HttpClientContextFactory(WebClientContextFactory):
 
-    def __init__(self, verify_options=None):
+    def __init__(self, verify_options=None, method=None):
         self.verify_options = verify_options
+        if method is not None:
+            self.method = method
 
     def verify_callback(self, conn, cert, errno, errdepth, ok):
         return ok
@@ -779,7 +782,12 @@ class HttpClientResource(SandboxResource):
             'VERIFY_NONE': VERIFY_NONE,
             'VERIFY_PEER': VERIFY_PEER,
             'VERIFY_CLIENT_ONCE': VERIFY_CLIENT_ONCE,
-            'VERIFY_FAIL_IF_NO_PEER_CERT': VERIFY_FAIL_IF_NO_PEER_CERT
+            'VERIFY_FAIL_IF_NO_PEER_CERT': VERIFY_FAIL_IF_NO_PEER_CERT,
+        }
+        method_map = {
+            'SSLv3': SSLv3_METHOD,
+            'SSLv23': SSLv23_METHOD,
+            'TLSv1': TLSv1_METHOD,
         }
 
         if 'verify_options' in command:
@@ -788,9 +796,14 @@ class HttpClientResource(SandboxResource):
             verify_options = reduce(operator.or_, verify_options)
         else:
             verify_options = None
+        if 'ssl_method' in command:
+            # TODO: Fail better with unknown method.
+            ssl_method = method_map[command['ssl_method']]
+        else:
+            ssl_method = None
 
         context_factory = HttpClientContextFactory(
-            verify_options=verify_options)
+            verify_options=verify_options, method=ssl_method)
 
         headers = command.get('headers', {})
         headers = dict((k.encode("utf-8"), [x.encode("utf-8") for x in v])

--- a/vumi/application/tests/test_sandbox.py
+++ b/vumi/application/tests/test_sandbox.py
@@ -9,7 +9,8 @@ import logging
 from collections import defaultdict
 
 from OpenSSL.SSL import (
-    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_NONE)
+    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_NONE,
+    SSLv3_METHOD, SSLv23_METHOD, TLSv1_METHOD)
 
 from twisted.internet.defer import (
     inlineCallbacks, fail, succeed, DeferredQueue)
@@ -1058,3 +1059,51 @@ class TestHttpClientResource(ResourceTestCaseBase):
         self.assertEqual(
             ctxt.verify_options,
             VERIFY_PEER | VERIFY_FAIL_IF_NO_PEER_CERT)
+
+    @inlineCallbacks
+    def test_https_request_method_default(self):
+        self.http_request_succeed("foo")
+        reply = yield self.dispatch_command(
+            'get', url='https://www.example.com')
+        self.assertTrue(reply['success'])
+        self.assertEqual(reply['body'], "foo")
+        self.assert_http_request('https://www.example.com', method='GET')
+
+        ctxt = self.get_context_factory()
+        self.assertEqual(ctxt.method, SSLv23_METHOD)
+
+    @inlineCallbacks
+    def test_https_request_method_SSLv3(self):
+        self.http_request_succeed("foo")
+        reply = yield self.dispatch_command(
+            'get', url='https://www.example.com', ssl_method='SSLv3')
+        self.assertTrue(reply['success'])
+        self.assertEqual(reply['body'], "foo")
+        self.assert_http_request('https://www.example.com', method='GET')
+
+        ctxt = self.get_context_factory()
+        self.assertEqual(ctxt.method, SSLv3_METHOD)
+
+    @inlineCallbacks
+    def test_https_request_method_SSLv23(self):
+        self.http_request_succeed("foo")
+        reply = yield self.dispatch_command(
+            'get', url='https://www.example.com', ssl_method='SSLv23')
+        self.assertTrue(reply['success'])
+        self.assertEqual(reply['body'], "foo")
+        self.assert_http_request('https://www.example.com', method='GET')
+
+        ctxt = self.get_context_factory()
+        self.assertEqual(ctxt.method, SSLv23_METHOD)
+
+    @inlineCallbacks
+    def test_https_request_method_TLSv1(self):
+        self.http_request_succeed("foo")
+        reply = yield self.dispatch_command(
+            'get', url='https://www.example.com', ssl_method='TLSv1')
+        self.assertTrue(reply['success'])
+        self.assertEqual(reply['body'], "foo")
+        self.assert_http_request('https://www.example.com', method='GET')
+
+        ctxt = self.get_context_factory()
+        self.assertEqual(ctxt.method, TLSv1_METHOD)


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/861137
As a result all HTTPS based calls from Vumi will most likely fail on this platform with the error: 

```
'SSL routines', 'SSL23_GET_SERVER_HELLO',
'tlsv1 alert internal error'
```

this patch is a work around:

``` diff
diff --git a/vumi/application/sandbox.py b/vumi/application/sandbox.py
index d845359..c76d8f5 100644
--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -20,7 +20,8 @@ from twisted.python.failure import Failure
 from twisted.web.client import WebClientContextFactory

 from OpenSSL.SSL import (
-    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_CLIENT_ONCE, VERIFY_NONE)
+    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_CLIENT_ONCE, VERIFY_NONE,
+    SSLv3_METHOD)

 from vumi.config import ConfigText, ConfigInt, ConfigList, ConfigDict
 from vumi.application.base import ApplicationWorker
@@ -708,6 +709,8 @@ class LoggingResource(SandboxResource):

 class HttpClientContextFactory(WebClientContextFactory):

+    method = SSLv3_METHOD
+
     def __init__(self, verify_options=None):
         self.verify_options = verify_options
```
