### PR TITLE
Log twitter api failures in twitter transport

### DIFF
--- a/vumi/transports/twitter/tests/test_twitter.py
+++ b/vumi/transports/twitter/tests/test_twitter.py
@@ -342,10 +342,15 @@ class TestTwitterTransport(VumiTestCase):
 
         self.patch(self.client, 'statuses_update', fail)
 
-        msg = yield self.tx_helper.make_dispatch_outbound(
-            'hello', endpoint='tweet_endpoint')
-        [nack] = yield self.tx_helper.wait_for_dispatched_events(1)
+        with LogCatcher() as lc:
+            msg = yield self.tx_helper.make_dispatch_outbound(
+                'hello', endpoint='tweet_endpoint')
 
+            self.assertEqual(
+                [e['message'][0] for e in lc.errors],
+                ["'Outbound twitter message failed: :('"])
+
+        [nack] = yield self.tx_helper.wait_for_dispatched_events(1)
         self.assertEqual(nack['user_message_id'], msg['message_id'])
         self.assertEqual(nack['sent_message_id'], msg['message_id'])
         self.assertEqual(nack['nack_reason'], ':(')
@@ -375,10 +380,15 @@ class TestTwitterTransport(VumiTestCase):
 
         self.patch(self.client, 'direct_messages_new', fail)
 
-        msg = yield self.tx_helper.make_dispatch_outbound(
-            'hello', endpoint='dm_endpoint')
-        [nack] = yield self.tx_helper.wait_for_dispatched_events(1)
+        with LogCatcher() as lc:
+            msg = yield self.tx_helper.make_dispatch_outbound(
+                'hello', endpoint='dm_endpoint')
 
+            self.assertEqual(
+                [e['message'][0] for e in lc.errors],
+                ["'Outbound twitter message failed: :('"])
+
+        [nack] = yield self.tx_helper.wait_for_dispatched_events(1)
         self.assertEqual(nack['user_message_id'], msg['message_id'])
         self.assertEqual(nack['sent_message_id'], msg['message_id'])
         self.assertEqual(nack['nack_reason'], ':(')

--- a/vumi/transports/twitter/twitter.py
+++ b/vumi/transports/twitter/twitter.py
@@ -112,10 +112,13 @@ class TwitterTransport(Transport):
                     user_message_id=message['message_id'],
                     sent_message_id=twitter_message['id_str'])
             except Exception, e:
+                reason = '%s' % (e,)
+                log.err('Outbound twitter message failed: %s' % (reason,))
+
                 yield self.publish_nack(
                     user_message_id=message['message_id'],
                     sent_message_id=message['message_id'],
-                    reason='%s' % (e,))
+                    reason=reason)
 
         return handler
 


### PR DESCRIPTION
At the moment, we publish nacks, but don't log anything.
