### PR TITLE
Mxit transport needs to unquote_plus content received.

### DIFF
--- a/vumi/transports/mxit/mxit.py
+++ b/vumi/transports/mxit/mxit.py
@@ -1,7 +1,7 @@
 # -*- test-case-name: vumi.transports.mxit.tests.test_mxit -*-
 import json
 import base64
-from urllib import urlencode
+from urllib import urlencode, unquote_plus
 from HTMLParser import HTMLParser
 
 from twisted.web import http
@@ -122,11 +122,11 @@ class MxitTransport(HttpRpcTransport):
 
     def get_request_content(self, request):
         if request.args and 'input' in request.args:
-            content = request.args['input']
+            [content] = request.args['input']
         else:
             headers = request.requestHeaders
-            content = headers.getRawHeaders('X-Mxit-User-Input', [None])
-        return content[0]
+            [content] = headers.getRawHeaders('X-Mxit-User-Input', [None])
+        return (None if content is None else unquote_plus(content))
 
     def handle_raw_inbound_message(self, msg_id, request):
         if not self.is_mxit_request(request):

--- a/vumi/transports/mxit/tests/test_mxit.py
+++ b/vumi/transports/mxit/tests/test_mxit.py
@@ -1,6 +1,5 @@
 import json
 import base64
-import urllib
 
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
 from twisted.web.http import Request, BAD_REQUEST
@@ -141,6 +140,18 @@ class TestMxitTransport(VumiTestCase):
         req = Request(None, True)
         req.requestHeaders.addRawHeader('X-Mxit-User-Input', 'foo')
         self.assertEqual(self.transport.get_request_content(req), 'foo')
+
+    def test_get_quote_plus_request_content_from_header(self):
+        req = Request(None, True)
+        req.requestHeaders.addRawHeader('X-Mxit-User-Input', 'foo+bar')
+        self.assertEqual(
+            self.transport.get_request_content(req), 'foo bar')
+
+    def test_get_quoted_request_content_from_header(self):
+        req = Request(None, True)
+        req.requestHeaders.addRawHeader('X-Mxit-User-Input', 'foo%20bar')
+        self.assertEqual(
+            self.transport.get_request_content(req), 'foo bar')
 
     def test_get_request_content_from_args(self):
         req = Request(None, True)


### PR DESCRIPTION
They're sending "97+dorp+street+stellenbosch" where as we'd expect them to use `%20` instead of `+` for spaces.

See http://stackoverflow.com/questions/1634271/url-encoding-the-space-character-or-20 for context.
