### PR TITLE
WeChat unsubscribe events not being handled properly

### DIFF
--- a/vumi/transports/wechat/message_types.py
+++ b/vumi/transports/wechat/message_types.py
@@ -10,7 +10,7 @@ from vumi.transports.wechat.errors import (
 
 def get_child_value(node, name):
     [child] = node.findall(name)
-    return child.text.strip()
+    return (child.text.strip() if child.text is not None else '')
 
 
 def append(node, tag, value):

--- a/vumi/transports/wechat/tests/test_wechat.py
+++ b/vumi/transports/wechat/tests/test_wechat.py
@@ -149,9 +149,7 @@ class TestWeChatInboundMessaging(WeChatTestCase):
                     <Event>
                         <![CDATA[subscribe]]>
                     </Event>
-                    <EventKey>
-                        <![CDATA[]]>
-                    </EventKey>
+                    <EventKey><![CDATA[]]></EventKey>
                 </xml>
                 """)
         self.assertEqual(resp.code, http.OK)


### PR DESCRIPTION
```
2014-04-16 04:09:52+0000 [-] <xml><ToUserName><![CDATA[gh_00780d74d04e]]></ToUserName>
2014-04-16 04:09:52+0000 [-] <FromUserName><![CDATA[owsArtykOMo-7uebocxkM_xGXgsU]]></FromUserName>
2014-04-16 04:09:52+0000 [-] <CreateTime>1397621349</CreateTime>
2014-04-16 04:09:52+0000 [-] <MsgType><![CDATA[event]]></MsgType>
2014-04-16 04:09:52+0000 [-] <Event><![CDATA[subscribe]]></Event>
2014-04-16 04:09:52+0000 [-] <EventKey><![CDATA[]]></EventKey>
2014-04-16 04:09:52+0000 [-] </xml>
2014-04-16 04:09:52+0000 [-] Unhandled error in Deferred:
2014-04-16 04:09:52+0000 [-] Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1201, in mainLoop
            self.runUntilCurrent()
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/base.py", line 824, in runUntilCurrent
            call.func(*call.args, **call.kw)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 382, in callback
            self._startRunCallbacks(result)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 490, in _startRunCallbacks
            self._runCallbacks()
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/transports/wechat/wechat.py", line 133, in handle_request
            wc_msg = WeChatXMLParser.parse(xml)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/transports/wechat/message_types.py", line 193, in parse
            return klass.from_xml(doc)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/transports/wechat/message_types.py", line 33, in from_xml
            params.append(get_child_value(doc, field))
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/transports/wechat/message_types.py", line 13, in get_child_value
            return child.text.strip()
        exceptions.AttributeError: 'NoneType' object has no attribute 'strip'
```
