### PR TITLE
Stop using AMQP channel.flow

### DIFF
--- a/vumi/blinkenlights/metrics.py
+++ b/vumi/blinkenlights/metrics.py
@@ -441,9 +441,9 @@ class MetricsConsumer(Consumer):
     routing_key = "vumi.metrics"
     durable = True
 
-    def __init__(self, channel, client, callback):
+    def __init__(self, channel, callback):
         self.queue_name = self.routing_key
-        super(MetricsConsumer, self).__init__(channel, client)
+        super(MetricsConsumer, self).__init__(channel)
         self.callback = callback
 
     def consume_message(self, vumi_message):

--- a/vumi/blinkenlights/metrics_workers.py
+++ b/vumi/blinkenlights/metrics_workers.py
@@ -32,9 +32,9 @@ class AggregatedMetricConsumer(Consumer):
     durable = True
     routing_key = "vumi.metrics.aggregates"
 
-    def __init__(self, channel, client, callback):
+    def __init__(self, channel, callback):
         self.queue_name = self.routing_key
-        super(AggregatedMetricConsumer, self).__init__(channel, client)
+        super(AggregatedMetricConsumer, self).__init__(channel)
         self.callback = callback
 
     def consume_message(self, vumi_message):
@@ -76,10 +76,10 @@ class TimeBucketConsumer(Consumer):
     durable = True
     ROUTING_KEY_TEMPLATE = "bucket.%d"
 
-    def __init__(self, channel, client, bucket, callback):
+    def __init__(self, channel, bucket, callback):
         self.queue_name = self.ROUTING_KEY_TEMPLATE % bucket
         self.routing_key = self.queue_name
-        super(TimeBucketConsumer, self).__init__(channel, client)
+        super(TimeBucketConsumer, self).__init__(channel)
         self.callback = callback
 
     def consume_message(self, vumi_message):

--- a/vumi/blinkenlights/tests/test_metrics.py
+++ b/vumi/blinkenlights/tests/test_metrics.py
@@ -492,7 +492,7 @@ class TestMetricsConsumer(VumiTestCase):
             ]
         datapoints = []
         callback = lambda *v: datapoints.append(v)
-        consumer = metrics.MetricsConsumer(None, None, callback)
+        consumer = metrics.MetricsConsumer(None, callback)
         msg = metrics.MetricMessage()
         msg.extend(expected_datapoints)
         vumi_msg = Message.from_json(msg.to_json())

--- a/vumi/tests/fake_amqp.py
+++ b/vumi/tests/fake_amqp.py
@@ -282,12 +282,13 @@ class FakeAMQPBroker(object):
 
 
 class FakeAMQPChannel(object):
-    def __init__(self, channel_id, broker, delegate):
+    def __init__(self, channel_id, client):
         self.channel_id = channel_id
-        self.broker = broker
+        self.client = client
+        self.broker = client.broker
         self.qos_prefetch_count = 0
         self.consumers = {}
-        self.delegate = delegate
+        self.delegate = client.delegate
         self.unacked = []
 
     def __repr__(self):
@@ -474,7 +475,7 @@ class FakeAMQClient(WorkerAMQClient):
             try:
                 ch = self.channels[id]
             except KeyError:
-                ch = FakeAMQPChannel(id, self.broker, self.delegate)
+                ch = FakeAMQPChannel(id, self)
                 self.channels[id] = ch
         finally:
             self.channelLock.release()

--- a/vumi/tests/test_fake_amqp.py
+++ b/vumi/tests/test_fake_amqp.py
@@ -10,7 +10,7 @@ def mkmsg(body):
     return fake_amqp.Thing("Message", body=body)
 
 
-class TestWorker(Worker):
+class ToyWorker(Worker):
     @inlineCallbacks
     def startWorker(self):
         paused = self.config.get('paused', False)
@@ -22,6 +22,15 @@ class TestWorker(Worker):
 
     def consume_msg(self, msg):
         self.msgs.append(msg)
+
+
+class ToyAMQClient(object):
+    """
+    A fake fake client object for building fake channel objects.
+    """
+    def __init__(self, broker, delegate):
+        self.broker = broker
+        self.delegate = delegate
 
 
 class TestFakeAMQP(VumiTestCase):
@@ -38,7 +47,8 @@ class TestFakeAMQP(VumiTestCase):
         return self.broker.queues[queue]
 
     def make_channel(self, channel_id, delegate=None):
-        channel = fake_amqp.FakeAMQPChannel(channel_id, self.broker, delegate)
+        channel = fake_amqp.FakeAMQPChannel(
+            channel_id, ToyAMQClient(self.broker, delegate))
         channel.channel_open()
         return channel
 
@@ -56,7 +66,7 @@ class TestFakeAMQP(VumiTestCase):
         spec = get_spec(vumi_resource_path("amqp-spec-0-8.xml"))
         amq_client = fake_amqp.FakeAMQClient(spec, {}, self.broker)
 
-        worker = TestWorker({}, config)
+        worker = ToyWorker({}, config)
         worker._amqp_client = amq_client
         yield worker.startWorker()
         returnValue(worker)
@@ -68,7 +78,7 @@ class TestFakeAMQP(VumiTestCase):
         self.assertRaises(AttributeError, lambda: msg.bar)
 
     def test_channel_open(self):
-        channel = fake_amqp.FakeAMQPChannel(0, self.broker, None)
+        channel = fake_amqp.FakeAMQPChannel(0, ToyAMQClient(self.broker, None))
         self.assertEqual([], self.broker.channels)
         channel.channel_open()
         self.assertEqual([channel], self.broker.channels)
@@ -265,7 +275,7 @@ class TestFakeAMQP(VumiTestCase):
     #     wc = WorkerCreator(options)
     #     d = Deferred()
 
-    #     class TestWorker(Worker):
+    #     class ToyWorker(Worker):
     #         @inlineCallbacks
     #         def startWorker(self):
     #             self.pub = yield self.publish_to('test.pub')
@@ -279,7 +289,7 @@ class TestFakeAMQP(VumiTestCase):
     #             print "CONSUMED!", msg
     #             return True
 
-    #     worker = wc.create_worker_by_class(TestWorker, {})
+    #     worker = wc.create_worker_by_class(ToyWorker, {})
     #     worker.startService()
     #     yield d
     #     print "foo"


### PR DESCRIPTION
As per http://www.rabbitmq.com/blog/2014/04/02/breaking-things-with-rabbitmq-3-3/ RabbitMQ no longer supports `channel.flow()`. We need to find a new way to pause consumers.
