### PR TITLE
Fix consumer pausing again

### DIFF
--- a/vumi/tests/test_fake_amqp.py
+++ b/vumi/tests/test_fake_amqp.py
@@ -331,7 +331,6 @@ class TestFakeAMQP(VumiTestCase):
         yield worker.con.pause()
         yield self.broker.wait_delivery()
         yield worker.conpub.publish_json({'message': 'bar'})
-        yield self.broker.wait_delivery()
         self.assertEqual([], worker.msgs)
 
         yield worker.con.unpause()

--- a/vumi/transports/smpp/deprecated/tests/test_smpp.py
+++ b/vumi/transports/smpp/deprecated/tests/test_smpp.py
@@ -251,7 +251,8 @@ class TestSmppTransport(VumiTestCase):
         clock.advance(0.05)
         yield self.transport.redis.exists('wait for redis')
         assert_throttled_status(True, ["Heimlich"], [])
-        yield self.tx_helper.make_dispatch_outbound("Other", message_id="448")
+        # Don't wait for this, because it won't be processed until later.
+        self.tx_helper.make_dispatch_outbound("Other", message_id="448")
         assert_throttled_status(True, ["Heimlich"], [])
         # Resent
         clock.advance(0.05)
@@ -291,7 +292,8 @@ class TestSmppTransport(VumiTestCase):
         clock.advance(0.05)
         yield self.transport.redis.exists('wait for redis')
         assert_throttled_status(True, ["Heimlich"], [])
-        yield self.tx_helper.make_dispatch_outbound("Other", message_id="448")
+        # Don't wait for this, because it won't be processed until later.
+        self.tx_helper.make_dispatch_outbound("Other", message_id="448")
         assert_throttled_status(True, ["Heimlich"], [])
         # Resent
         clock.advance(0.05)


### PR DESCRIPTION
We need to pause at the end of the current message, not the whole queue.
