### PR TITLE
Model migration detection

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -213,6 +213,7 @@ class Model(object):
                                   " to model %s" % (field_values.keys(),
                                                     self.__class__))
         self.clean()
+        self.was_migrated = False
 
     def __repr__(self):
         str_items = ["%s=%r" % item for item

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -446,6 +446,7 @@ class TestModelOnTxRiak(VumiTestCase):
         s2 = yield simple_model.load("foo")
         self.assertEqual(s2.a, 5)
         self.assertEqual(s2.b, u'3')
+        self.assertEqual(s2.was_migrated, False)
 
     @Manager.calls_manager
     def test_simple_instance_delete(self):
@@ -947,6 +948,7 @@ class TestModelOnTxRiak(VumiTestCase):
 
         foo_new = yield new_model.load("foo")
         self.assertEqual(foo_new.c, 1)
+        self.assertEqual(foo_new.was_migrated, True)
 
     @Manager.calls_manager
     def test_version_migration(self):
@@ -958,6 +960,7 @@ class TestModelOnTxRiak(VumiTestCase):
         foo_new = yield new_model.load("foo")
         self.assertEqual(foo_new.c, 1)
         self.assertEqual(foo_new.text, "hello")
+        self.assertEqual(foo_new.was_migrated, True)
 
     @Manager.calls_manager
     def test_version_migration_new_index(self):
@@ -970,6 +973,7 @@ class TestModelOnTxRiak(VumiTestCase):
         self.assertEqual(foo_new.c, 1)
         self.assertEqual(foo_new.text, "hi")
         self.assertEqual(self.get_model_indexes(foo_new), {"text_bin": ["hi"]})
+        self.assertEqual(foo_new.was_migrated, True)
 
     @Manager.calls_manager
     def test_version_migration_new_index_None(self):


### PR DESCRIPTION
It is useful (mostly in migration scripts) to know whether a loaded model was migrated from an old version or not.
