### PR TITLE
Avoid easy_install of riak_pb by apt-get installing protobuf-compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ matrix:
 services:
   - riak
   - redis-server
+before_install:
+  # we need the protobuf-compiler so we can install Riak client libraries
+  - sudo apt-get install -qq protobuf-compiler
 install:
   # We easy_install a binary riak_pb package because pip install needs `protoc'.
   - "pip install ${TWISTED_VERSION}"
-  - "easy_install 'riak_pb<1.3.0'"
   - "pip install -r requirements.pip --use-wheel"
   - "pip install coveralls --use-wheel"
   - "python setup.py install"


### PR DESCRIPTION
`easy_install` is rapidly becoming a thing of the past and this matches what people are likely to do in production more closely (and is less magic).
