### PR TITLE
Sandbox commands shouldn't try parse all fields as dates

### DIFF
--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -1,3 +1,6 @@
+import json
+from datetime import datetime
+
 from vumi.tests.utils import RegexMatcher, UTCNearNow
 from vumi.message import (Message, TransportMessage, TransportEvent,
                           TransportUserMessage)
@@ -15,6 +18,12 @@ class MessageTest(VumiTestCase):
     def test_message_contains(self):
         self.assertTrue('a' in Message(a=5))
         self.assertFalse('a' in Message(b=5))
+
+    def test_from_json_date_parsing(self):
+        msg = Message.from_json(json.dumps({
+            'timestamp': '1969-08-18 08:00:00.00'
+        }))
+        self.assertEqual(msg['timestamp'], datetime(1969, 8, 18, 8, 0))
 
 
 class TransportMessageTestMixin(object):


### PR DESCRIPTION
`SandboxCommand` is a subclass of `Message`, so its fields get parsed with [`date_time_decoder`](https://github.com/praekelt/vumi/blob/develop/vumi/message.py#L16-L25). This is causing problems in the sandbox contacts resource for cases where we try save contacts with extra fields that can be parsed with `datetime.strptime`.
