### PR TITLE
SandboxCommand should not use timestamp-enabled JSON transforms

### DIFF
--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -32,8 +32,7 @@ from vumi.application.base import ApplicationWorker
 from vumi.message import Message
 from vumi.errors import ConfigError
 from vumi.persist.txredis_manager import TxRedisManager
-from vumi.utils import (
-    load_class_by_string, HttpDataLimitError)
+from vumi.utils import load_class_by_string, HttpDataLimitError, to_kwargs
 from vumi import log
 from vumi.application.sandbox_rlimiter import SandboxRlimiter
 
@@ -1101,6 +1100,11 @@ class SandboxCommand(Message):
             'cmd_id',
             'reply',
         )
+
+    @classmethod
+    def from_json(cls, json_string):
+        # We override this to avoid the datetime conversions.
+        return cls(_process_fields=False, **to_kwargs(json.loads(json_string)))
 
 
 class SandboxConfig(ApplicationWorker.CONFIG_CLASS):

--- a/vumi/application/tests/test_sandbox.py
+++ b/vumi/application/tests/test_sandbox.py
@@ -8,6 +8,7 @@ import resource
 import pkg_resources
 import logging
 from collections import defaultdict
+from datetime import datetime
 
 from OpenSSL.SSL import (
     VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_NONE,
@@ -379,6 +380,14 @@ class TestSandbox(SandboxTestCaseBase):
         ack = self.app_helper.make_ack(sandbox_id='sandbox1')
         ack.set_routing_endpoint('foo')
         return self.event_dispatch_check(ack)
+
+    def test_sandbox_command_does_not_parse_timestamps(self):
+        # We should serialise datetime objects correctly.
+        timestamp = datetime(2014, 07, 18, 15, 0, 0)
+        json_cmd = SandboxCommand(cmd='foo', timestamp=timestamp).to_json()
+        # We should not parse timestamp-like strings into datetime objects.
+        cmd = SandboxCommand.from_json(json_cmd)
+        self.assertEqual(cmd['timestamp'], "2014-07-18 15:00:00.000000")
 
 
 class JsSandboxTestMixin(object):


### PR DESCRIPTION
This is related to #825, #826, and #827. It doesn't touch `vumi.Message` and therefore limits the impact on other code.
