### PR TITLE
fix error message when not connecting to AMQP

### DIFF
--- a/vumi/service.py
+++ b/vumi/service.py
@@ -55,7 +55,7 @@ class AmqpFactory(protocol.ReconnectingClientFactory):
         return self.amqp_client
 
     def clientConnectionFailed(self, connector, reason):
-        log.err("Connection failed: %r" % (reason,))
+        log.err("AmqpFactory connection failed (%s)" % (reason.getErrorMessage(),))
         self.worker._amqp_connection_failed()
         self.amqp_client = None
         protocol.ReconnectingClientFactory.clientConnectionFailed(
@@ -65,7 +65,7 @@ class AmqpFactory(protocol.ReconnectingClientFactory):
         if not self.worker.running:
             # We've specifically asked for this disconnect.
             return
-        log.err("Client connection lost: %r" % (reason,))
+        log.err("AmqpFactory client connection lost (%s)" % (reason.getErrorMessage(),))
         self.worker._amqp_connection_failed()
         self.amqp_client = None
         protocol.ReconnectingClientFactory.clientConnectionLost(


### PR DESCRIPTION
New log:

```
2014-09-08 17:51:25+0200 [Uninitialized] 'AmqpFactory connection failed (Connection was refused by other side: 111: Connection refused.)'
2014-09-08 17:51:25+0200 [Uninitialized] <twisted.internet.tcp.Connector instance at 0x7f42cf47ab90> will retry in 3 seconds
```

old log:

```
2014-09-08 17:58:40+0200 [Uninitialized] "Connection failed: <twisted.python.failure.Failure <class 'twisted.internet.error.ConnectionRefusedError'>>"
2014-09-08 17:58:40+0200 [Uninitialized] <twisted.internet.tcp.Connector instance at 0x7f906efefb90> will retry in 2 seconds
2014-09-08 17:58:40+0200 [Uninitialized] Stopping factory <vumi.service.AmqpFactory instance at 0x7f906cac86c8>
```
