### PR TITLE
Fix readthedocs.

### DIFF
--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,5 +1,3 @@
-Sphinx==1.0.7
-repoze.sphinx.autointerface
 coverage
 python-subunit
 junitxml

--- a/requirements-docs.pip
+++ b/requirements-docs.pip
@@ -1,0 +1,6 @@
+# These are the requirements for building the docs, used by readthedocs.org for
+# publishing docs on http://vumi-go.readthedocs.org/
+Sphinx
+sphinxcontrib-blockdiag>=1.3.1
+repoze.sphinx.autointerface
+-e .


### PR DESCRIPTION
Currently readthedocs builds are failing because our requirements are not installed nicely. We need a `requirements-docs.txt` like Vumi Go has.
