### PR TITLE
fix-null-continuation

### DIFF
--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -11,6 +11,8 @@ from vumi.utils import flatten_generator
 
 
 def to_unicode(text, encoding='utf-8'):
+    if text is None:
+        return text
     if isinstance(text, tuple):
         return tuple(to_unicode(item, encoding) for item in text)
     if not isinstance(text, unicode):

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -585,6 +585,16 @@ class TestModelOnTxRiak(VumiTestCase):
         keys3 = yield keys2.next_page()
         self.assertEqual(sorted(keys3), ["foo4"])
         self.assertEqual(keys3.has_next_page(), False)
+        
+    @Manager.calls_manager
+    def test_index_keys_page_none_continuation(self):
+        indexed_model = self.manager.proxy(IndexedModel)
+        yield indexed_model("foo1", a=1, b=u'one').save()
+        
+        keys1 = yield indexed_model.index_keys_page('a', 1, max_results=2)
+        self.assertEqual(sorted(keys1), ['foo1'])
+        self.assertEqual(keys1.has_next_page(), False)
+        self.assertEqual(keys1.continuation, None)
 
     @Manager.calls_manager
     def test_index_keys_quoting(self):

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -13,6 +13,8 @@ from vumi.persist.model import Manager
 
 
 def to_unicode(text, encoding='utf-8'):
+    if text is None:
+        return text
     if isinstance(text, tuple):
         return tuple(to_unicode(item, encoding) for item in text)
     if not isinstance(text, unicode):


### PR DESCRIPTION
With Riak pagination, if the continuation cursor is `None`, it fails in the `to_unicode` function in `riak_manager` used in the `VumiIndexPage` class.
