### PR TITLE
Clear bucket properties when purging a manager.

### DIFF
--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -269,6 +269,11 @@ class RiakManager(Manager):
         bucket = self.client.bucket(bucket_name)
         return bucket.enable_search()
 
+    def riak_search_enabled(self, modelcls):
+        bucket_name = self.bucket_name(modelcls)
+        bucket = self.client.bucket(bucket_name)
+        return bucket.search_enabled()
+
     def should_quote_index_values(self):
         return False
 
@@ -279,3 +284,4 @@ class RiakManager(Manager):
                 for key in bucket.get_keys():
                     obj = bucket.get(key)
                     obj.delete()
+                bucket.clear_properties()

--- a/vumi/persist/tests/test_txriak_manager.py
+++ b/vumi/persist/tests/test_txriak_manager.py
@@ -219,6 +219,24 @@ class CommonRiakManagerTests(object):
         self.assertEqual(result, None)
 
     @Manager.calls_manager
+    def test_purge_all_clears_bucket_properties(self):
+        search_enabled = yield self.manager.riak_search_enabled(DummyModel)
+        self.assertEqual(search_enabled, False)
+
+        yield self.manager.riak_enable_search(DummyModel)
+        search_enabled = yield self.manager.riak_search_enabled(DummyModel)
+        self.assertEqual(search_enabled, True)
+
+        # We need at least one key in here so the bucket can be found and
+        # purged.
+        dummy = self.mkdummy("foo", {"baz": 0})
+        yield self.manager.store(dummy)
+
+        yield self.manager.purge_all()
+        search_enabled = yield self.manager.riak_search_enabled(DummyModel)
+        self.assertEqual(search_enabled, False)
+
+    @Manager.calls_manager
     def test_json_decoding(self):
         # Some versions of the riak client library use simplejson by
         # preference, which breaks some of our unicode assumptions. This test


### PR DESCRIPTION
This is a new implementation of #308 that should improve test performance slightly, especially on repeated runs. I haven't yet run any thorough benchmarks, but leftover bucket properties have always caused slowdowns.
