### PR TITLE
Disable unique address tracking in message store cache

### DIFF
--- a/vumi/components/message_store_cache.py
+++ b/vumi/components/message_store_cache.py
@@ -342,45 +342,69 @@ class MessageStoreCache(object):
         Add a from_addr to this batch_id, weighted by timestamp. Generally
         this information is retrieved when `add_inbound_message()` is called.
         """
-        return self.redis.zadd(self.from_addr_key(batch_id), **{
-            from_addr.encode('utf-8'): timestamp,
-        })
+        # NOTE: Disabled because this doesn't scale to large batches.
+        #       See https://github.com/praekelt/vumi/issues/877
+
+        # return self.redis.zadd(self.from_addr_key(batch_id), **{
+        #     from_addr.encode('utf-8'): timestamp,
+        # })
+        return
 
     def get_from_addrs(self, batch_id, asc=False):
         """
         Return a set of all known from_addrs sorted by timestamp.
         """
-        return self.redis.zrange(self.from_addr_key(batch_id), 0, -1,
-                                 desc=not asc)
+        # NOTE: Disabled because this doesn't scale to large batches.
+        #       See https://github.com/praekelt/vumi/issues/877
+
+        # return self.redis.zrange(self.from_addr_key(batch_id), 0, -1,
+        #                          desc=not asc)
+        return []
 
     def count_from_addrs(self, batch_id):
         """
         Return the number of from_addrs for this batch_id
         """
-        return self.redis.zcard(self.from_addr_key(batch_id))
+        # NOTE: Disabled because this doesn't scale to large batches.
+        #       See https://github.com/praekelt/vumi/issues/877
+
+        # return self.redis.zcard(self.from_addr_key(batch_id))
+        return 0
 
     def add_to_addr(self, batch_id, to_addr, timestamp):
         """
         Add a to-addr to this batch_id, weighted by timestamp. Generally
         this information is retrieved when `add_outbound_message()` is called.
         """
-        return self.redis.zadd(self.to_addr_key(batch_id), **{
-            to_addr.encode('utf-8'): timestamp,
-        })
+        # NOTE: Disabled because this doesn't scale to large batches.
+        #       See https://github.com/praekelt/vumi/issues/877
+
+        # return self.redis.zadd(self.to_addr_key(batch_id), **{
+        #     to_addr.encode('utf-8'): timestamp,
+        # })
+        return
 
     def get_to_addrs(self, batch_id, asc=False):
         """
         Return a set of unique to_addrs addressed in this batch ordered
         by the most recent timestamp.
         """
-        return self.redis.zrange(self.to_addr_key(batch_id), 0, -1,
-                                 desc=not asc)
+        # NOTE: Disabled because this doesn't scale to large batches.
+        #       See https://github.com/praekelt/vumi/issues/877
+
+        # return self.redis.zrange(self.to_addr_key(batch_id), 0, -1,
+        #                          desc=not asc)
+        return []
 
     def count_to_addrs(self, batch_id):
         """
         Return count of the unique to_addrs in this batch.
         """
-        return self.redis.zcard(self.to_addr_key(batch_id))
+        # NOTE: Disabled because this doesn't scale to large batches.
+        #       See https://github.com/praekelt/vumi/issues/877
+
+        # return self.redis.zcard(self.to_addr_key(batch_id))
+        return 0
 
     def get_inbound_message_keys(self, batch_id, start=0, stop=-1, asc=False,
                                  with_timestamp=False):

--- a/vumi/components/tests/test_message_store.py
+++ b/vumi/components/tests/test_message_store.py
@@ -717,20 +717,22 @@ class TestMessageStoreCache(TestMessageStoreBase):
         msg_id, msg, batch_id = yield self._create_outbound()
         [cached_msg_id] = (
             yield self.store.cache.get_outbound_message_keys(batch_id))
-        [cached_to_addr] = (
-            yield self.store.cache.get_to_addrs(batch_id))
+        cached_to_addrs = yield self.store.cache.get_to_addrs(batch_id)
         self.assertEqual(msg_id, cached_msg_id)
-        self.assertEqual(msg['to_addr'], cached_to_addr)
+        # NOTE: This functionality is disabled for now.
+        # self.assertEqual([msg['to_addr']], cached_to_addrs)
+        self.assertEqual([], cached_to_addrs)
 
     @inlineCallbacks
     def test_cache_add_inbound_message(self):
         msg_id, msg, batch_id = yield self._create_inbound()
         [cached_msg_id] = (
             yield self.store.cache.get_inbound_message_keys(batch_id))
-        [cached_from_addr] = (
-            yield self.store.cache.get_from_addrs(batch_id))
+        cached_from_addrs = yield self.store.cache.get_from_addrs(batch_id)
         self.assertEqual(msg_id, cached_msg_id)
-        self.assertEqual(msg['from_addr'], cached_from_addr)
+        # NOTE: This functionality is disabled for now.
+        # self.assertEqual([msg['from_addr']], cached_from_addrs)
+        self.assertEqual([], cached_from_addrs)
 
     @inlineCallbacks
     def test_cache_add_event(self):

--- a/vumi/components/tests/test_message_store_cache.py
+++ b/vumi/components/tests/test_message_store_cache.py
@@ -147,28 +147,36 @@ class TestMessageStoreCache(MessageStoreCacheTestCase):
         yield self.add_messages(
             self.batch_id, self.cache.add_inbound_message)
         from_addrs = yield self.cache.get_from_addrs(self.batch_id)
-        self.assertEqual(from_addrs, ['from-%s' % i for i in range(10)])
+        # NOTE: This functionality is disabled for now.
+        # self.assertEqual(from_addrs, ['from-%s' % i for i in range(10)])
+        self.assertEqual(from_addrs, [])
 
     @inlineCallbacks
     def test_count_from_addrs(self):
         yield self.add_messages(
             self.batch_id, self.cache.add_inbound_message)
         count = yield self.cache.count_from_addrs(self.batch_id)
-        self.assertEqual(count, 10)
+        # NOTE: This functionality is disabled for now.
+        # self.assertEqual(count, 10)
+        self.assertEqual(count, 0)
 
     @inlineCallbacks
     def test_get_to_addrs(self):
         yield self.add_messages(
             self.batch_id, self.cache.add_outbound_message)
         to_addrs = yield self.cache.get_to_addrs(self.batch_id)
-        self.assertEqual(to_addrs, ['to-%s' % i for i in range(10)])
+        # NOTE: This functionality is disabled for now.
+        # self.assertEqual(to_addrs, ['to-%s' % i for i in range(10)])
+        self.assertEqual(to_addrs, [])
 
     @inlineCallbacks
     def test_count_to_addrs(self):
         yield self.add_messages(
             self.batch_id, self.cache.add_outbound_message)
         count = yield self.cache.count_to_addrs(self.batch_id)
-        self.assertEqual(count, 10)
+        # NOTE: This functionality is disabled for now.
+        # self.assertEqual(count, 10)
+        self.assertEqual(count, 0)
 
     @inlineCallbacks
     def test_add_event(self):


### PR DESCRIPTION
This is expensive for large batches and should either be removed entirely (in favour of walking indexes) or replaced with a hyperloglog solution.
