### PR TITLE
Support writing older model versions

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -85,7 +85,8 @@ class BackLinkProxy(object):
 
 
 class ModelMigrator(object):
-    """Migration handler for old Model versions.
+    """
+    Migration handler for old Model versions.
 
     Subclasses of this should implement ``migrate_from_<version>()`` methods
     for each previous version of the model being migrated. This method will
@@ -99,22 +100,30 @@ class ModelMigrator(object):
 
     There is a special-case ``migrate_from_unversioned()`` method that is
     called for objects that do not contain a model version.
+
+    In order to facilitate different processes using different model versions,
+    reverse migrations are also supported. These are similar to forward
+    migrations, except they are applied at save time (rather than load time)
+    and methods are named ``reverse_from_<version>()``.
     """
-    def __init__(self, model_class, manager, data_version):
+    def __init__(self, model_class, manager, data_version, reverse=False):
         self.model_class = model_class
         self.manager = manager
         self.data_version = data_version
+        self.reverse = reverse
+        prefix = "reverse" if reverse else "migrate"
         if data_version is not None:
-            migration_method_name = 'migrate_from_%s' % str(data_version)
+            migration_method_name = '%s_from_%s' % (prefix, str(data_version))
         else:
-            migration_method_name = 'migrate_from_unversioned'
+            migration_method_name = '%s_from_unversioned' % (prefix,)
         self.migration_method = getattr(self, migration_method_name, None)
 
     def __call__(self, riak_object):
         if self.migration_method is None:
+            prefix = "reverse " if self.reverse else ""
             raise ModelMigrationError(
-                'No migrators defined for %s version %s' % (
-                    self.model_class.__name__, self.data_version))
+                'No %smigrators defined for %s version %s' % (
+                    prefix, self.model_class.__name__, self.data_version))
         return self.migration_method(MigrationData(riak_object))
 
 
@@ -130,6 +139,7 @@ class MigrationData(object):
 
     def get_riak_object(self):
         self.riak_object.set_data(self.new_data)
+        # Note: This keeps old indexes.
         for field, values in self.new_index.iteritems():
             for value in values:
                 self.riak_object.add_index(field, value)
@@ -640,13 +650,14 @@ class Manager(object):
     USE_MAPREDUCE_BUNCH_LOADING = False
 
     def __init__(self, client, bucket_prefix, load_bunch_size=None,
-                 mapreduce_timeout=None):
+                 mapreduce_timeout=None, store_versions=None):
         self.client = client
         self.bucket_prefix = bucket_prefix
         self.load_bunch_size = load_bunch_size or self.DEFAULT_LOAD_BUNCH_SIZE
         self.mapreduce_timeout = (mapreduce_timeout or
                                   self.DEFAULT_MAPREDUCE_TIMEOUT)
         self._bucket_cache = {}
+        self.store_versions = store_versions or {}
 
     def proxy(self, modelcls):
         return ModelProxy(self, modelcls)

--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -169,11 +169,12 @@ class RiakManager(Manager):
     def from_config(cls, config):
         config = config.copy()
         bucket_prefix = config.pop('bucket_prefix')
-        load_bunch_size = config.pop('load_bunch_size',
-                                     cls.DEFAULT_LOAD_BUNCH_SIZE)
-        mapreduce_timeout = config.pop('mapreduce_timeout',
-                                       cls.DEFAULT_MAPREDUCE_TIMEOUT)
+        load_bunch_size = config.pop(
+            'load_bunch_size', cls.DEFAULT_LOAD_BUNCH_SIZE)
+        mapreduce_timeout = config.pop(
+            'mapreduce_timeout', cls.DEFAULT_MAPREDUCE_TIMEOUT)
         transport_type = config.pop('transport_type', 'http')
+        store_versions = config.pop('store_versions', None)
 
         host = config.get('host', '127.0.0.1')
         port = config.get('port')
@@ -199,8 +200,9 @@ class RiakManager(Manager):
         client.set_encoder('text/json', json.dumps)
         client.set_decoder('application/json', json.loads)
         client.set_decoder('text/json', json.loads)
-        return cls(client, bucket_prefix, load_bunch_size=load_bunch_size,
-                   mapreduce_timeout=mapreduce_timeout)
+        return cls(
+            client, bucket_prefix, load_bunch_size=load_bunch_size,
+            mapreduce_timeout=mapreduce_timeout, store_versions=store_versions)
 
     def close_manager(self):
         self.client.close()
@@ -233,7 +235,18 @@ class RiakManager(Manager):
         return riak_object
 
     def store(self, modelobj):
-        modelobj._riak_object.store()
+        riak_object = modelobj._riak_object
+        modelcls = type(modelobj)
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        store_version = self.store_versions.get(model_name, modelcls.VERSION)
+        # Run reverse migrators until we have the correct version of the data.
+        data_version = riak_object.get_data().get('$VERSION', None)
+        while data_version != store_version:
+            migrator = modelcls.MIGRATOR(
+                modelcls, self, data_version, reverse=True)
+            riak_object = migrator(riak_object).get_riak_object()
+            data_version = riak_object.get_data().get('$VERSION', None)
+        riak_object.store()
         return modelobj
 
     def delete(self, modelobj):


### PR DESCRIPTION
When a new model version is introduced, anything using the new code starts writing the new version. However, anything using the old code can't yet read the new version. We need a way to write old versions of models while still reading new versions to avoid deploy-time issues with different workers using different model versions.

A possible mechanism for this is to add "back migrations" that can be applied at write time the same way migrations are applied at read time. We can then configure the manager to write particular models at a particular version while still using the newest version internally.
