### PR TITLE
Stop logging SMPP throttling messages at WARNING level.

### DIFF
--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -521,9 +521,9 @@ class SmppTransceiverTransport(Transport):
     def start_throttling(self, quiet=False):
         if self.throttled:
             return
-        # We always want to log throttling messages, but we don't always want
-        # them to be warnings.
-        logger = log.msg if quiet else log.warning
+        # We used to use `quiet` to decide log level, but now we always use
+        # `log.msg`.
+        logger = log.msg
         logger("Throttling outbound messages.")
         self.throttled = True
         return self.pause_connectors()
@@ -531,9 +531,9 @@ class SmppTransceiverTransport(Transport):
     def stop_throttling(self, quiet=False):
         if not self.throttled:
             return
-        # We always want to log throttling messages, but we don't always want
-        # them to be warnings.
-        logger = log.msg if quiet else log.warning
+        # We used to use `quiet` to decide log level, but now we always use
+        # `log.msg`.
+        logger = log.msg
         logger("No longer throttling outbound messages.")
         self.throttled = False
         self.unpause_connectors()

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -555,7 +555,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
                              message_id='foo',
                              command_status='ESME_RTHROTTLED'))
         [logmsg] = lc.logs
-        self.assertEqual(logmsg['logLevel'], logging.WARNING)
+        self.assertEqual(logmsg['logLevel'], logging.INFO)
 
         self.clock.advance(transport_config.throttle_delay)
 
@@ -577,7 +577,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         with LogCatcher(message="No longer throttling outbound") as lc:
             self.clock.advance(transport_config.throttle_delay)
         [logmsg] = lc.logs
-        self.assertEqual(logmsg['logLevel'], logging.WARNING)
+        self.assertEqual(logmsg['logLevel'], logging.INFO)
 
     @inlineCallbacks
     def test_mt_sms_throttle_while_throttled(self):


### PR DESCRIPTION
This is very spammy.
