### PR TITLE
Fix sending for mxit transport

### DIFF
--- a/vumi/transports/mxit/mxit.py
+++ b/vumi/transports/mxit/mxit.py
@@ -33,7 +33,7 @@ class MxitTransportConfig(HttpRpcTransport.CONFIG_CLASS):
         'How to connect to Redis', required=True, static=True)
     api_send_url = ConfigText(
         'The URL for the Mxit message sending API.',
-        required=False, default="https://api.mxit.com",
+        required=False, default="https://api.mxit.com/message/send/",
         static=True)
     api_auth_url = ConfigText(
         'The URL for the Mxit authentication API.',
@@ -41,7 +41,7 @@ class MxitTransportConfig(HttpRpcTransport.CONFIG_CLASS):
         static=True)
     api_auth_scopes = ConfigList(
         'The list of scopes to request access to.',
-        required=False, static=True, default=['message/user'])
+        required=False, static=True, default=['message/send'])
 
 
 class MxitTransport(HttpRpcTransport):

--- a/vumi/transports/mxit/tests/test_mxit.py
+++ b/vumi/transports/mxit/tests/test_mxit.py
@@ -242,7 +242,7 @@ class TestMxitTransport(VumiTestCase):
             auth, 'Basic %s' % (
                 base64.b64encode('client_id:client_secret')))
         self.assertEqual(
-            'scope=message%2Fuser&grant_type=client_credentials',
+            'scope=message%2Fsend&grant_type=client_credentials',
             req.content.read())
         req.write(json.dumps({
             'access_token': 'access_token',


### PR DESCRIPTION
There were two issues:
- The url to hit for sending messages changed
- For the cases where we were requesting an api token from mxit, we get a json response, so we were giving twisted a unicode header for the authorization token, which made twisted sad.
