### PR TITLE
SMPP transport fails to send empty message

### DIFF
--- a/vumi/transports/smpp/processors/default.py
+++ b/vumi/transports/smpp/processors/default.py
@@ -469,6 +469,8 @@ class SubmitShortMessageProcessor(object):
         to_addr = message['to_addr']
         from_addr = message['from_addr']
         text = message['content']
+        if text is None:
+            text = u""
         vumi_message_id = message['message_id']
 
         # TODO: this should probably be handled by a processor as these

--- a/vumi/transports/smpp/processors/mica.py
+++ b/vumi/transports/smpp/processors/mica.py
@@ -129,6 +129,8 @@ class SubmitShortMessageProcessor(default.SubmitShortMessageProcessor):
         to_addr = message['to_addr']
         from_addr = message['from_addr']
         text = message['content']
+        if text is None:
+            text = u""
         vumi_message_id = message['message_id']
 
         session_event = message['session_event']

--- a/vumi/transports/smpp/tests/test_mica.py
+++ b/vumi/transports/smpp/tests/test_mica.py
@@ -248,3 +248,24 @@ class MicaProcessorTestCase(SmppTransportTestCase):
         self.assertEqual(pdu_tlv(submit_sm_pdu, 'ussd_service_op'), '17')
         self.assertEqual(pdu_tlv(submit_sm_pdu, 'user_message_reference'),
                          session_identifier)
+
+    @inlineCallbacks
+    def test_submit_sm_null_message(self):
+        """
+        We can successfully send a message with null content.
+        """
+        user_msisdn = 'msisdn'
+        session_identifier = 12345
+        smpp_helper = yield self.get_smpp_helper()
+
+        yield self.tx_helper.make_dispatch_outbound(
+            None,
+            transport_type="ussd",
+            session_event=TransportUserMessage.SESSION_RESUME,
+            transport_metadata={
+                'session_info': {
+                    'session_identifier': session_identifier
+                }
+            }, to_addr=user_msisdn)
+        [resume] = yield smpp_helper.wait_for_pdus(1)
+        self.assertEqual(pdu_tlv(resume, 'ussd_service_op'), '02')

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -647,6 +647,18 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
             u'Zoë destroyer of Ascii!'.encode('latin-1'))
 
     @inlineCallbacks
+    def test_mt_sms_submit_sm_null_message(self):
+        """
+        We can successfully send a message with null content.
+        """
+        smpp_helper = yield self.get_smpp_helper()
+        msg = self.tx_helper.make_outbound(None)
+        yield self.tx_helper.dispatch_outbound(msg)
+        [pdu] = yield smpp_helper.wait_for_pdus(1)
+        self.assertEqual(command_id(pdu), 'submit_sm')
+        self.assertEqual(short_message(pdu), None)
+
+    @inlineCallbacks
     def test_submit_sm_data_coding(self):
         smpp_helper = yield self.get_smpp_helper(config={
             'submit_short_message_processor_config': {


### PR DESCRIPTION
Specifically, it can't encode `None`. We can fall back to an empty string instead.

There's probably no reason for us to ever send empty messages, but we can receive them without any problems and there doesn't seem to be any reason to forbid them either.