### PR TITLE
add priority for middleware

### DIFF
--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -239,14 +239,16 @@ def create_middlewares_from_config(worker, config):
         middleware_config = config.get(middleware_name, {})
         if type(item[middleware_name]) is str:
             cls_name = item[middleware_name]
+            middleware_config['consume_priority'] = 0
+            middleware_config['publish_priority'] = 0
         elif type(item[middleware_name]) is dict:
             conf = item[middleware_name]
             cls_name = conf.get('class')
             try:
                 middleware_config['consume_priority'] = int(conf.get(
-                    'consume_priority', None))
+                    'consume_priority', 0))
                 middleware_config['publish_priority'] = int(conf.get(
-                    'publish_priority', None))
+                    'publish_priority', 0))
             except ValueError:
                 raise ConfigError(
                     "Middleware priority level must be an integer")

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -184,12 +184,10 @@ class MiddlewareStack(object):
 
     @staticmethod
     def _sort_by_priority(middlewares, priority_key):
-        priorities = defaultdict(list)
-        for mw in middlewares:
-            priorities[mw.config.get(priority_key, None)].append(mw)
-        sorted_priorities = sorted(
-            priorities.keys(), key=lambda a: '' if not a else a)
-        return [mw for p in sorted_priorities for mw in priorities[p]]
+        sorted_middlewares = sorted(
+            (mw.config[priority_key], idx, mw)
+            for idx, mw in enumerate(middlewares))
+        return [mw for priority, idx, mw in sorted_middlewares]
 
     @inlineCallbacks
     def _handle(self, middlewares, handler_name, message, connector_name):

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -187,8 +187,8 @@ class MiddlewareStack(object):
         priorities = defaultdict(list)
         for mw in middlewares:
             priorities[mw.config.get(priority_key, None)].append(mw)
-        sorted_priorities = [p for p in sorted(
-            priorities.keys(), key=lambda a: '' if not a else a)]
+        sorted_priorities = sorted(
+            priorities.keys(), key=lambda a: '' if not a else a)
         return [mw for p in sorted_priorities for mw in priorities[p]]
 
     @inlineCallbacks

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -184,10 +184,7 @@ class MiddlewareStack(object):
 
     @staticmethod
     def _sort_by_priority(middlewares, priority_key):
-        sorted_middlewares = sorted(
-            (mw.config[priority_key], idx, mw)
-            for idx, mw in enumerate(middlewares))
-        return [mw for priority, idx, mw in sorted_middlewares]
+        return sorted(middlewares, key=lambda mw: mw.config[priority_key])
 
     @inlineCallbacks
     def _handle(self, middlewares, handler_name, message, connector_name):

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -232,11 +232,11 @@ def create_middlewares_from_config(worker, config):
                 " with the priority level for publishing, both integers.")
         middleware_name = keys[0]
         middleware_config = config.get(middleware_name, {})
-        if type(item[middleware_name]) is str:
+        if isinstance(item[middleware_name], basestring):
             cls_name = item[middleware_name]
             middleware_config['consume_priority'] = 0
             middleware_config['publish_priority'] = 0
-        elif type(item[middleware_name]) is dict:
+        elif isinstance(item[middleware_name], dict):
             conf = item[middleware_name]
             cls_name = conf.get('class')
             try:

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -186,7 +186,7 @@ class MiddlewareStack(object):
     def _sort_by_priority(middlewares, priority_key):
         priorities = defaultdict(list)
         for mw in middlewares:
-            priorities[mw.config.get(priority_key, None)] = mw
+            priorities[mw.config.get(priority_key, None)].append(mw)
         sorted_priorities = [p for p in sorted(
             priorities.keys(), key=lambda a: '' if not a else a)]
         return [mw for p in sorted_priorities for mw in priorities[p]]

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -1,6 +1,4 @@
 # -*- test-case-name: vumi.middleware.tests.test_base -*-
-from collections import defaultdict
-
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.utils import load_class_by_string

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -239,8 +239,6 @@ def create_middlewares_from_config(worker, config):
         middleware_config = config.get(middleware_name, {})
         if type(item[middleware_name]) is str:
             cls_name = item[middleware_name]
-            middleware_config['consume_priority'] = None
-            middleware_config['publish_priority'] = None
         elif type(item[middleware_name]) is dict:
             conf = item[middleware_name]
             cls_name = conf.get('class')

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -182,6 +182,8 @@ class MiddlewareStack(object):
 
     @staticmethod
     def _sort_by_priority(middlewares, priority_key):
+        # We rely on Python's sorting algorithm being stable to preserve
+        # order within priority levels.
         return sorted(middlewares, key=lambda mw: mw.config[priority_key])
 
     @inlineCallbacks

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -242,10 +242,20 @@ def create_middlewares_from_config(worker, config):
         elif type(item[middleware_name]) is dict:
             conf = item[middleware_name]
             cls_name = conf.get('class')
-            middleware_config['consume_priority'] = conf.get(
-                'consume_priority', None)
-            middleware_config['publish_priority'] = conf.get(
-                'publish_priority', None)
+            try:
+                middleware_config['consume_priority'] = int(conf.get(
+                    'consume_priority', None))
+                middleware_config['publish_priority'] = int(conf.get(
+                    'publish_priority', None))
+            except ValueError:
+                raise ConfigError(
+                    "Middleware priority level must be an integer")
+        else:
+            raise ConfigError(
+                "Middleware item values must either be a string with the",
+                " full dotted name of the class implementing the middleware,"
+                " or a dictionary with 'class', 'consume_priority', and"
+                " 'publish_priority' keys.")
         cls = load_class_by_string(cls_name)
         middleware = cls(middleware_name, middleware_config, worker)
         middlewares.append(middleware)

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -281,12 +281,11 @@ class TestUtilityFunctions(VumiTestCase):
     @inlineCallbacks
     def test_sort_by_priority(self):
         priority2 = ToyMiddleware('priority2', {"priority": 2}, self)
-        nopriority = ToyMiddleware('nopriority', {}, self)
         priority1_1 = ToyMiddleware('priority1_1', {"priority": 1}, self)
         priority1_2 = ToyMiddleware('priority1_2', {"priority": 1}, self)
-        middlewares = [priority2, nopriority, priority1_1, priority1_2]
+        middlewares = [priority2, priority1_1, priority1_2]
         for mw in middlewares:
             yield mw.setup_middleware()
         mw_sorted = MiddlewareStack._sort_by_priority(middlewares, 'priority')
         self.assertEqual(
-            mw_sorted, [priority1_1, priority1_2, priority2, nopriority])
+            mw_sorted, [priority1_1, priority1_2, priority2])

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -94,7 +94,7 @@ class TestMiddlewareStack(VumiTestCase):
         mw = mw_class(
             name, {
                 'consume_priority': consume_pri,
-                'publish_priority': publish_pri
+                'publish_priority': publish_pri,
                 }, self)
         yield mw.setup_middleware()
         returnValue(mw)

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -217,8 +217,11 @@ class TestUtilityFunctions(VumiTestCase):
     TEST_CONFIG_1 = {
         "middleware": [
             {"mw1": "vumi.middleware.tests.test_base.ToyMiddleware"},
-            {"mw2": "vumi.middleware.tests.test_base.ToyMiddleware"},
-            ],
+            {"mw2": {
+                'class': "vumi.middleware.tests.test_base.ToyMiddleware",
+                'consume_priority': 1,
+                'publish_priority': -1}},
+        ],
         "mw1": {
             "param_foo": 1,
             "param_bar": 2,
@@ -239,9 +242,13 @@ class TestUtilityFunctions(VumiTestCase):
                          [ToyMiddleware, ToyMiddleware])
         self.assertEqual([mw._setup_done for mw in middlewares],
                          [False, False])
-        self.assertEqual(middlewares[0].config,
-                         {"param_foo": 1, "param_bar": 2})
-        self.assertEqual(middlewares[1].config, {})
+        self.assertEqual(
+            middlewares[0].config, {
+                "param_foo": 1, "param_bar": 2,
+                'consume_priority': 0, 'publish_priority': 0})
+        self.assertEqual(
+            middlewares[1].config,
+            {'consume_priority': 1, 'publish_priority': -1})
 
     @inlineCallbacks
     def test_setup_middleware_from_config(self):
@@ -252,9 +259,13 @@ class TestUtilityFunctions(VumiTestCase):
                          [ToyMiddleware, ToyMiddleware])
         self.assertEqual([mw._setup_done for mw in middlewares],
                          [True, True])
-        self.assertEqual(middlewares[0].config,
-                         {"param_foo": 1, "param_bar": 2})
-        self.assertEqual(middlewares[1].config, {})
+        self.assertEqual(
+            middlewares[0].config, {
+                "param_foo": 1, "param_bar": 2,
+                'consume_priority': 0, 'publish_priority': 0})
+        self.assertEqual(
+            middlewares[1].config,
+            {'consume_priority': 1, 'publish_priority': -1})
 
     def test_parse_yaml(self):
         # this test is here to ensure the YAML one has to

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -225,3 +225,16 @@ class TestUtilityFunctions(VumiTestCase):
                          [ToyMiddleware, ToyMiddleware])
         self.assertEqual([mw._setup_done for mw in middlewares],
                          [False, False])
+
+    @inlineCallbacks
+    def test_sort_by_priority(self):
+        priority2 = ToyMiddleware('priority2', {"priority": 2}, self)
+        nopriority = ToyMiddleware('nopriority', {}, self)
+        priority1_1 = ToyMiddleware('priority1_1', {"priority": 1}, self)
+        priority1_2 = ToyMiddleware('priority1_2', {"priority": 1}, self)
+        middlewares = [priority2, nopriority, priority1_1, priority1_2]
+        for mw in middlewares:
+            yield mw.setup_middleware()
+        mw_sorted = MiddlewareStack._sort_by_priority(middlewares, 'priority')
+        self.assertEqual(
+            mw_sorted, [priority1_1, priority1_2, priority2, nopriority])

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -85,7 +85,8 @@ class TestMiddlewareStack(VumiTestCase):
 
     @inlineCallbacks
     def mkmiddleware(self, name, mw_class):
-        mw = mw_class(name, {}, self)
+        mw = mw_class(
+            name, {'consume_priority': 0, 'publish_priority': 0}, self)
         yield mw.setup_middleware()
         returnValue(mw)
 

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -194,21 +194,21 @@ class TestMiddlewareStack(VumiTestCase):
         self.assert_processed([])
         yield self.stack.apply_consume('event', 'dummy_msg', 'end_foo')
         self.assert_processed([
-            ('pasym', 'event', 'dummy_msg.pasym', 'end_foo'),
-            ('p1_1', 'event', 'dummy_msg.pasym.p1_1', 'end_foo'),
-            ('p1_2', 'event', 'dummy_msg.pasym.p1_1.p1_2', 'end_foo'),
-            ('p2', 'event', 'dummy_msg.pasym.p1_1.p1_2.p2', 'end_foo'),
-            ('pn', 'event', 'dummy_msg.pasym.p1_1.p1_2.p2.pn', 'end_foo'),
+            ('pn', 'event', 'dummy_msg.pn', 'end_foo'),
+            ('pasym', 'event', 'dummy_msg.pn.pasym', 'end_foo'),
+            ('p1_1', 'event', 'dummy_msg.pn.pasym.p1_1', 'end_foo'),
+            ('p1_2', 'event', 'dummy_msg.pn.pasym.p1_1.p1_2', 'end_foo'),
+            ('p2', 'event', 'dummy_msg.pn.pasym.p1_1.p1_2.p2', 'end_foo'),
         ])
         # test publish
         self.processed_messages = []
         yield self.stack.apply_publish('event', 'dummy_msg', 'end_foo')
         self.assert_processed([
-            ('p1_2', 'event', 'dummy_msg.p1_2', 'end_foo'),
-            ('p1_1', 'event', 'dummy_msg.p1_2.p1_1', 'end_foo'),
-            ('p2', 'event', 'dummy_msg.p1_2.p1_1.p2', 'end_foo'),
-            ('pasym', 'event', 'dummy_msg.p1_2.p1_1.p2.pasym', 'end_foo'),
-            ('pn', 'event', 'dummy_msg.p1_2.p1_1.p2.pasym.pn', 'end_foo'),
+            ('pn', 'event', 'dummy_msg.pn', 'end_foo'),
+            ('p1_2', 'event', 'dummy_msg.pn.p1_2', 'end_foo'),
+            ('p1_1', 'event', 'dummy_msg.pn.p1_2.p1_1', 'end_foo'),
+            ('p2', 'event', 'dummy_msg.pn.p1_2.p1_1.p2', 'end_foo'),
+            ('pasym', 'event', 'dummy_msg.pn.p1_2.p1_1.p2.pasym', 'end_foo'),
         ])
 
 

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -197,7 +197,7 @@ class TestMiddlewareStack(VumiTestCase):
             ('p1_1', 'event', 'dummy_msg.pasym.p1_1', 'end_foo'),
             ('p1_2', 'event', 'dummy_msg.pasym.p1_1.p1_2', 'end_foo'),
             ('p2', 'event', 'dummy_msg.pasym.p1_1.p1_2.p2', 'end_foo'),
-            ('pn', 'event', 'dummy_msg.pasym.p1_1.p1_2.p2.pn', 'end_foo')
+            ('pn', 'event', 'dummy_msg.pasym.p1_1.p1_2.p2.pn', 'end_foo'),
         ])
         # test publish
         self.processed_messages = []
@@ -207,10 +207,8 @@ class TestMiddlewareStack(VumiTestCase):
             ('p1_1', 'event', 'dummy_msg.p1_2.p1_1', 'end_foo'),
             ('p2', 'event', 'dummy_msg.p1_2.p1_1.p2', 'end_foo'),
             ('pasym', 'event', 'dummy_msg.p1_2.p1_1.p2.pasym', 'end_foo'),
-            ('pn', 'event', 'dummy_msg.p1_2.p1_1.p2.pasym.pn', 'end_foo')
+            ('pn', 'event', 'dummy_msg.p1_2.p1_1.p2.pasym.pn', 'end_foo'),
         ])
-
-
 
 
 class TestUtilityFunctions(VumiTestCase):

--- a/vumi/middleware/tests/test_base.py
+++ b/vumi/middleware/tests/test_base.py
@@ -160,12 +160,12 @@ class TestMiddlewareStack(VumiTestCase):
     def test_teardown_in_reverse_order(self):
 
         def get_teardown_timestamps():
-            return [mw._teardown_done for mw in self.stack.middlewares]
+            return [mw._teardown_done for mw in self.stack.consume_middlewares]
 
         self.assertFalse(any(get_teardown_timestamps()))
         yield self.stack.teardown()
         self.assertTrue(all(get_teardown_timestamps()))
-        teardown_order = sorted(self.stack.middlewares,
+        teardown_order = sorted(self.stack.consume_middlewares,
             key=lambda mw: mw._teardown_done)
         self.assertEqual([mw.name for mw in teardown_order],
             ['mw3', 'mw2', 'mw1'])

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -64,8 +64,9 @@ class TestBaseConnector(BaseConnectorTestCase):
     @inlineCallbacks
     def test_middlewares_consume(self):
         worker = yield self.worker_helper.get_worker(DummyWorker, {})
-        middlewares = [RecordingMiddleware(str(i), {}, worker)
-                       for i in range(3)]
+        middlewares = [RecordingMiddleware(
+            str(i), {'consume_priority': 0, 'publish_priority': 0}, worker)
+            for i in range(3)]
         conn, consumer = yield self.mk_consumer(
             worker=worker, connector_name='foo', middlewares=middlewares)
         consumer.unpause()
@@ -81,8 +82,9 @@ class TestBaseConnector(BaseConnectorTestCase):
     @inlineCallbacks
     def test_middlewares_publish(self):
         worker = yield self.worker_helper.get_worker(DummyWorker, {})
-        middlewares = [RecordingMiddleware(str(i), {}, worker)
-                       for i in range(3)]
+        middlewares = [RecordingMiddleware(
+            str(i), {'consume_priority': 0, 'publish_priority': 0}, worker)
+            for i in range(3)]
         conn = yield self.mk_connector(
             worker=worker, connector_name='foo', middlewares=middlewares)
         yield conn._setup_publisher('outbound')


### PR DESCRIPTION
Add the ability to specify a `consume_priority` and `publish_priority` to each middleware when describing their order in the config files.

Middlewares are executed in order for consume, and reverse order for publish. All middlewares that have priority will be executed first, in priority order. Order will be in order for consume and reverse order for publish for middleware with the same priority level