### PR TITLE
FakeRedis ZREMRANGEBYRANK behaves differently from Redis

### DIFF
--- a/vumi/persist/fake_redis.py
+++ b/vumi/persist/fake_redis.py
@@ -503,10 +503,9 @@ class Zset(object):
         self._zval = []
 
     def _redis_range_to_py_range(self, start, end):
-        if start < 0:
-            start = len(self._zval) + start
-        if end < 0:
-            end = len(self._zval) + end
+        end += 1  # redis start/end are element indexes
+        if end == 0:
+            end = None
         return start, end
 
     def zadd(self, **valscores):
@@ -528,9 +527,7 @@ class Zset(object):
         return len(self._zval)
 
     def zrange(self, start, stop, desc=False, score_cast_func=float):
-        stop += 1  # redis start/stop are element indexes
-        if stop == 0:
-            stop = None
+        start, stop = self._redis_range_to_py_range(start, stop)
 
         # copy before changing in place
         zval = self._zval[:]
@@ -577,6 +574,6 @@ class Zset(object):
 
     def zremrangebyrank(self, start, stop):
         start, stop = self._redis_range_to_py_range(start, stop)
-        deleted_keys = self._zval[start:stop + 1]
-        del self._zval[start:stop + 1]
+        deleted_keys = self._zval[start:stop]
+        del self._zval[start:stop]
         return len(deleted_keys)

--- a/vumi/persist/tests/test_fake_redis.py
+++ b/vumi/persist/tests/test_fake_redis.py
@@ -164,6 +164,14 @@ class TestFakeRedis(VumiTestCase):
             [('three', 3)], 'zrange', 'set', 0, -1, withscores=True)
 
     @inlineCallbacks
+    def test_zremrangebyrank_empty_range(self):
+        yield self.redis.zadd('set', one=1, two=2, three=3)
+        yield self.assert_redis_op(0, 'zremrangebyrank', 'set', 10, 11)
+        yield self.assert_redis_op(
+            [('one', 1), ('two', 2), ('three', 3)],
+            'zrange', 'set', 0, -1, withscores=True)
+
+    @inlineCallbacks
     def test_zremrangebyrank_negative_start(self):
         yield self.redis.zadd('set', one=1, two=2, three=3)
         yield self.assert_redis_op(2, 'zremrangebyrank', 'set', -2, 2)

--- a/vumi/persist/tests/test_fake_redis.py
+++ b/vumi/persist/tests/test_fake_redis.py
@@ -171,11 +171,27 @@ class TestFakeRedis(VumiTestCase):
             [('one', 1)], 'zrange', 'set', 0, -1, withscores=True)
 
     @inlineCallbacks
+    def test_zremrangebyrank_negative_start_empty_range(self):
+        yield self.redis.zadd('set', one=1, two=2, three=3)
+        yield self.assert_redis_op(0, 'zremrangebyrank', 'set', -1, 1)
+        yield self.assert_redis_op(
+            [('one', 1), ('two', 2), ('three', 3)],
+            'zrange', 'set', 0, -1, withscores=True)
+
+    @inlineCallbacks
     def test_zremrangebyrank_negative_stop(self):
         yield self.redis.zadd('set', one=1, two=2, three=3)
         yield self.assert_redis_op(2, 'zremrangebyrank', 'set', 1, -1)
         yield self.assert_redis_op(
             [('one', 1)], 'zrange', 'set', 0, -1, withscores=True)
+
+    @inlineCallbacks
+    def test_zremrangebyrank_negative_stop_empty_range(self):
+        yield self.redis.zadd('set', one=1, two=2, three=3)
+        yield self.assert_redis_op(0, 'zremrangebyrank', 'set', 0, -5)
+        yield self.assert_redis_op(
+            [('one', 1), ('two', 2), ('three', 3)],
+            'zrange', 'set', 0, -1, withscores=True)
 
     @inlineCallbacks
     def test_zscore(self):

--- a/vumi/persist/tests/test_fake_redis.py
+++ b/vumi/persist/tests/test_fake_redis.py
@@ -172,6 +172,14 @@ class TestFakeRedis(VumiTestCase):
             'zrange', 'set', 0, -1, withscores=True)
 
     @inlineCallbacks
+    def test_zremrangebyrank_negative_empty_range(self):
+        yield self.redis.zadd('set', one=1, two=2, three=3)
+        yield self.assert_redis_op(0, 'zremrangebyrank', 'set', -11, -10)
+        yield self.assert_redis_op(
+            [('one', 1), ('two', 2), ('three', 3)],
+            'zrange', 'set', 0, -1, withscores=True)
+
+    @inlineCallbacks
     def test_zremrangebyrank_negative_start(self):
         yield self.redis.zadd('set', one=1, two=2, three=3)
         yield self.assert_redis_op(2, 'zremrangebyrank', 'set', -2, 2)


### PR DESCRIPTION
Specifically, it seems to remove the wrong number of entries in some cases.