### PR TITLE
add yaml import constructor

### DIFF
--- a/vumi/servicemaker.py
+++ b/vumi/servicemaker.py
@@ -50,7 +50,7 @@ def read_yaml_config(config_file, optional=True):
         return {}
     with file(config_file, 'r') as stream:
         # Assume we get a dict out of this.
-        return yaml.safe_load(stream)
+        return yaml.load(stream, Loader=SafeLoaderWithInclude)
 
 
 class VumiOptions(usage.Options):

--- a/vumi/servicemaker.py
+++ b/vumi/servicemaker.py
@@ -19,8 +19,11 @@ from vumi.sentry import SentryLoggerService
 class SafeLoaderWithInclude(yaml.SafeLoader):
     def __init__(self, *args, **kwargs):
         super(SafeLoaderWithInclude, self).__init__(*args, **kwargs)
-        self._root = os.path.split(self.stream.name)[0]
         self.add_constructor('!include', self._include)
+        if isinstance(self.stream, file):
+            self._root = os.path.dirname(self.stream.name)
+        else:
+            self._root = os.path.curdir
 
     def _include(self, loader, node):
         filename = os.path.join(self._root, self.construct_scalar(node))


### PR DESCRIPTION
There is no way to import yaml files from within yaml files. This would be useful for things like not having to repeat a list of provider prefixes for every transport, and instead listing a file in each of the transports, and having a single copy of that file.

I propose to do this by lightly wrapping the pyyaml `SafeLoader` class, and adding an `import` directive that will `safe_load` the specified file.