### PR TITLE
Better VumiIndexPage.next_page()

### DIFF
--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -62,6 +62,8 @@ class VumiIndexPage(object):
             A new :class:`VumiIndexPage` object containing the next page of
             results.
         """
+        if not self.has_next_page():
+            return None
         try:
             result = self._index_page.next_page()
         except RiakError as e:

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -727,6 +727,9 @@ class ModelTestMixin(object):
         self.assertEqual(sorted(keys3), [])
         self.assertEqual(keys3.has_next_page(), False)
 
+        no_keys = yield keys3.next_page()
+        self.assertEqual(no_keys, None)
+
     @Manager.calls_manager
     def test_index_keys_page_explicit_continuation(self):
         indexed_model = self.manager.proxy(IndexedModel)

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -7,7 +7,7 @@ import json
 from riak import RiakClient, RiakObject, RiakMapReduce, RiakError
 from twisted.internet.threads import deferToThread
 from twisted.internet.defer import (
-    inlineCallbacks, returnValue, gatherResults, maybeDeferred)
+    inlineCallbacks, returnValue, gatherResults, maybeDeferred, succeed)
 
 from vumi.persist.model import Manager, VumiRiakError
 
@@ -69,6 +69,8 @@ class VumiTxIndexPage(object):
             A new :class:`VumiTxIndexPage` object containing the next page of
             results.
         """
+        if not self.has_next_page():
+            return succeed(None)
         d = deferToThread(self._index_page.next_page)
         d.addCallback(type(self))
         d.addErrback(riakErrorHandler)


### PR DESCRIPTION
To avoid having to check `.has_next_page()` all the time, `.next_page()` should return `None` on the last page.