### PR TITLE
Add support for __cache__ on Vumi Message objects that contains data that should not be stored by the message store.

### DIFF
--- a/vumi/message.py
+++ b/vumi/message.py
@@ -109,6 +109,13 @@ class Message(object):
     def copy(self):
         return self.from_json(self.to_json())
 
+    @property
+    def cache(self):
+        """
+        A special payload attribute that isn't stored by the message store.
+        """
+        return self.payload.setdefault('__cache__', {})
+
 
 class TransportMessage(Message):
     """Common base class for messages sent to or from a transport."""

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -46,9 +46,9 @@ class Message(object):
     A unified message object used by Vumi when transmitting messages over AMQP
     and occassionally as a standardised JSON format for use in external APIs.
 
-    The special ``.cache`` attribute stores a dictionary of data that is not
-    stored by the ``vumi.fields.VumiMessage`` and hence not stored by the
-    Vumi message store.
+    The special ``.cache`` property stores a dictionary of data that is not
+    stored by the :class:`vumi.fields.VumiMessage` field and hence not stored
+    by Vumi's message store.
     """
 
     # name of the special attribute that isn't stored by the message store

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -43,13 +43,16 @@ def to_json(obj):
 
 class Message(object):
     """
-    Start of a somewhat unified message object to be
-    used internally in Vumi and while being in transit
-    over AMQP
+    A unified message object used by Vumi when transmitting messages over AMQP
+    and occassionally as a standardised JSON format for use in external APIs.
 
-    scary transport format -> Vumi Tansport -> Unified Message -> Vumi Worker
-
+    The special ``.cache`` attribute stores a dictionary of data that is not
+    stored by the ``vumi.fields.VumiMessage`` and hence not stored by the
+    Vumi message store.
     """
+
+    # name of the special attribute that isn't stored by the message store
+    _CACHE_ATTRIBUTE = "__cache__"
 
     def __init__(self, _process_fields=True, **kwargs):
         if _process_fields:
@@ -114,7 +117,7 @@ class Message(object):
         """
         A special payload attribute that isn't stored by the message store.
         """
-        return self.payload.setdefault('__cache__', {})
+        return self.payload.setdefault(self._CACHE_ATTRIBUTE, {})
 
 
 class TransportMessage(Message):

--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -264,6 +264,7 @@ class VumiMessageDescriptor(FieldDescriptor):
 
     def setup(self, model_cls):
         super(VumiMessageDescriptor, self).setup(model_cls)
+        self.message_class = self.field.message_class
         if self.field.prefix is None:
             self.prefix = "%s." % self.key
         else:
@@ -286,7 +287,7 @@ class VumiMessageDescriptor(FieldDescriptor):
         if msg is None:
             return
         for key, value in msg.payload.iteritems():
-            if key == "__cache__":
+            if key == self.message_class._CACHE_ATTRIBUTE:
                 continue
             # TODO: timestamp as datetime in payload must die.
             if key == "timestamp":

--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -286,6 +286,8 @@ class VumiMessageDescriptor(FieldDescriptor):
         if msg is None:
             return
         for key, value in msg.payload.iteritems():
+            if key == "__cache__":
+                continue
             # TODO: timestamp as datetime in payload must die.
             if key == "timestamp":
                 value = self._timestamp_to_json(value)
@@ -318,6 +320,11 @@ class VumiMessage(Field):
     :param string prefix:
         The prefix to use when storing message payload keys in Riak. Default is
         the name of the field followed by a dot ('.').
+
+    Note::
+
+       The special message attribute ``__cache__`` is not stored by this
+       field.
     """
     descriptor_class = VumiMessageDescriptor
 

--- a/vumi/persist/tests/test_fields.py
+++ b/vumi/persist/tests/test_fields.py
@@ -4,9 +4,11 @@
 
 from datetime import datetime
 
+from vumi.message import Message
+
 from vumi.persist.fields import (
     ValidationError, Field, Integer, Unicode, Tag, Timestamp, Json,
-    ListOf, SetOf, Dynamic, FieldWithSubtype, Boolean)
+    ListOf, SetOf, Dynamic, FieldWithSubtype, Boolean, VumiMessage)
 from vumi.tests.helpers import VumiTestCase
 
 
@@ -189,3 +191,14 @@ class TestSetOf(VumiTestCase):
         """
         f = SetOf()
         self.assertEqual(f.from_riak([1, 2, 3]), set([1, 2, 3]))
+
+
+class TestVumiMessage(VumiTestCase):
+    def test_validate(self):
+        f = VumiMessage(Message)
+        msg = Message()
+        f.validate(msg)
+        self.assertRaises(
+            ValidationError, f.validate, u'this is not a vumi message')
+        self.assertRaises(
+            ValidationError, f.validate, None)

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -850,6 +850,20 @@ class ModelTestMixin(object):
         m1.msg = msg2
         self.assertTrue("extra" not in m1.msg)
 
+    @Manager.calls_manager
+    def test_vumimessage_field_excludes_cache(self):
+        msg_model = self.manager.proxy(VumiMessageModel)
+        msg = self.mkmsg(extra="bar", __cache__={"cache": "me"})
+        self.assertEqual(msg["__cache__"], {"cache": "me"})
+
+        m1 = msg_model("foo", msg=msg)
+        self.assertTrue("__cache__" not in m1.msg)
+        yield m1.save()
+
+        m2 = yield msg_model.load("foo")
+        self.assertTrue("__cache__" not in m2.msg)
+        self.assertEqual(m2.msg, m1.msg)
+
     def _create_dynamic_instance(self, dynamic_model):
         d1 = dynamic_model("foo", a=u"ab")
         d1.contact_info['cellphone'] = u"+27123"

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -854,7 +854,8 @@ class ModelTestMixin(object):
     def test_vumimessage_field_excludes_cache(self):
         msg_model = self.manager.proxy(VumiMessageModel)
         cache_attr = TransportUserMessage._CACHE_ATTRIBUTE
-        msg = self.mkmsg(extra="bar", __cache__={"cache": "me"})
+        msg = self.mkmsg(extra="bar")
+        msg.cache["cache"] = "me"
         self.assertEqual(msg[cache_attr], {"cache": "me"})
 
         m1 = msg_model("foo", msg=msg)

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -853,15 +853,16 @@ class ModelTestMixin(object):
     @Manager.calls_manager
     def test_vumimessage_field_excludes_cache(self):
         msg_model = self.manager.proxy(VumiMessageModel)
+        cache_attr = TransportUserMessage._CACHE_ATTRIBUTE
         msg = self.mkmsg(extra="bar", __cache__={"cache": "me"})
-        self.assertEqual(msg["__cache__"], {"cache": "me"})
+        self.assertEqual(msg[cache_attr], {"cache": "me"})
 
         m1 = msg_model("foo", msg=msg)
-        self.assertTrue("__cache__" not in m1.msg)
+        self.assertTrue(cache_attr not in m1.msg)
         yield m1.save()
 
         m2 = yield msg_model.load("foo")
-        self.assertTrue("__cache__" not in m2.msg)
+        self.assertTrue(cache_attr not in m2.msg)
         self.assertEqual(m2.msg, m1.msg)
 
     def _create_dynamic_instance(self, dynamic_model):

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -16,6 +16,17 @@ class MessageTest(VumiTestCase):
         self.assertTrue('a' in Message(a=5))
         self.assertFalse('a' in Message(b=5))
 
+    def test_message_cache(self):
+        msg = Message(a=5)
+        self.assertEqual(msg.cache, {})
+        msg.cache["thing"] = "dont_store_me"
+        self.assertEqual(msg.cache, {
+            "thing": "dont_store_me",
+        })
+        self.assertEqual(msg["__cache__"], {
+            "thing": "dont_store_me",
+        })
+
 
 class TransportMessageTestMixin(object):
     def make_message(self, **fields):

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -23,7 +23,7 @@ class MessageTest(VumiTestCase):
         self.assertEqual(msg.cache, {
             "thing": "dont_store_me",
         })
-        self.assertEqual(msg["__cache__"], {
+        self.assertEqual(msg[Message._CACHE_ATTRIBUTE], {
             "thing": "dont_store_me",
         })
 


### PR DESCRIPTION
This is useful for attaching data to messages while they're being processed by a chain of workers.