### PR TITLE
Change session length middleware to not overwrite existing time metadata

### DIFF
--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -30,6 +30,9 @@ class SessionLengthMiddleware(BaseMiddleware):
     SESSION_NEW, SESSION_CLOSE = (
         TransportUserMessage.SESSION_NEW, TransportUserMessage.SESSION_CLOSE)
 
+    SESSION_START = 'session_start'
+    SESSION_END = 'session_end'
+
     @inlineCallbacks
     def setup_middleware(self):
         r_config = self.config.get('redis_manager', {})
@@ -42,43 +45,66 @@ class SessionLengthMiddleware(BaseMiddleware):
     def teardown_middleware(self):
         yield self.redis.close_manager()
 
+    def _time(self):
+        return self.clock.seconds()
+
     def _generate_redis_key(self, message, address):
         return '%s:%s:%s' % (
             message.get('transport_name'), address, 'session_created')
 
-    @inlineCallbacks
-    def _set_redis_time(self, redis_key, time):
-        if (yield self.redis.get(redis_key)) is None:
-            yield self.redis.setex(redis_key,  self.timeout, str(time))
-
-    def _set_message_session_metadata(self, message, field, value):
+    def _set_metadata(self, message, key, value):
         metadata = message['helper_metadata'].setdefault(self.field_name, {})
-        metadata.setdefault(field, value)
+        metadata[key] = float(value)
 
-    def _set_session_start_time(self, message, time):
-        time = float(time)
-        self._set_message_session_metadata(message, 'session_start', time)
+    def _has_metadata(self, message, key):
+        metadata = message['helper_metadata'].setdefault(self.field_name, {})
+        return key in metadata
 
-    def _set_session_end_time(self, message, time):
-        time = float(time)
-        self._set_message_session_metadata(message, 'session_end', time)
+    @inlineCallbacks
+    def _set_new_start_time(self, message, redis_key, time):
+        yield self.redis.setex(redis_key, self.timeout, str(time))
+        self._set_metadata(message, self.SESSION_START, time)
+
+    @inlineCallbacks
+    def _set_current_start_time(self, message, redis_key, clear):
+        created_time = yield self.redis.get(redis_key)
+
+        if created_time is not None:
+            self._set_metadata(message, self.SESSION_START, created_time)
+
+            if clear:
+                yield self.redis.delete(redis_key)
+
+    def _set_end_time(self, message, time):
+        self._set_metadata(message, self.SESSION_END, time)
+
+    @inlineCallbacks
+    def _handle_start(self, message, redis_key):
+        if not self._has_metadata(message, self.SESSION_START):
+            time = self._time()
+            yield self._set_new_start_time(message, redis_key, time)
+
+    @inlineCallbacks
+    def _handle_end(self, message, redis_key):
+        if not self._has_metadata(message, self.SESSION_END):
+            self._set_end_time(message, self._time())
+
+        if not self._has_metadata(message, self.SESSION_START):
+            yield self._set_current_start_time(message, redis_key, clear=True)
+
+    @inlineCallbacks
+    def _handle_default(self, message, redis_key):
+        if not self._has_metadata(message, self.SESSION_START):
+            yield self._set_current_start_time(message, redis_key, clear=False)
 
     @inlineCallbacks
     def _process_message(self, message, redis_key):
         if message.get('session_event') == self.SESSION_NEW:
-            start_time = self.clock.seconds()
-            yield self._set_redis_time(redis_key, start_time)
-            self._set_session_start_time(message, start_time)
+            yield self._handle_start(message, redis_key)
         elif message.get('session_event') == self.SESSION_CLOSE:
-            self._set_session_end_time(message, self.clock.seconds())
-            created_time = yield self.redis.get(redis_key)
-            if created_time:
-                self._set_session_start_time(message, created_time)
-                yield self.redis.delete(redis_key)
+            yield self._handle_end(message, redis_key)
         else:
-            created_time = yield self.redis.get(redis_key)
-            if created_time:
-                self._set_session_start_time(message, created_time)
+            yield self._handle_default(message, redis_key)
 
     @inlineCallbacks
     def handle_inbound(self, message, connector_name):


### PR DESCRIPTION
At the moment we overwrite existing time metadata.