### PR TITLE
Reduce default concurrency in message store resource

### DIFF
--- a/vumi/components/message_store_resource.py
+++ b/vumi/components/message_store_resource.py
@@ -38,7 +38,7 @@ class ParameterError(Exception):
 class MessageStoreProxyResource(Resource):
 
     isLeaf = True
-    default_concurrency = 3
+    default_concurrency = 1
 
     def __init__(self, message_store, batch_id, formatter):
         Resource.__init__(self)


### PR DESCRIPTION
Unless we have lots of cores available for the message store exports, the concurrency hurts us instead of helping us.