### PR TITLE
Format message store timestamp indexes more rigorously

### DIFF
--- a/vumi/components/message_store.py
+++ b/vumi/components/message_store.py
@@ -11,7 +11,8 @@ import warnings
 
 from twisted.internet.defer import returnValue
 
-from vumi.message import TransportEvent, TransportUserMessage, VUMI_DATE_FORMAT
+from vumi.message import (
+    TransportEvent, TransportUserMessage, parse_vumi_date, format_vumi_date)
 from vumi.persist.model import Model, Manager
 from vumi.persist.fields import (
     VumiMessage, ForeignKey, ManyToMany, ListOf, Tag, Dynamic, Unicode)
@@ -80,7 +81,7 @@ class OutboundMessage(Model):
         # We override this method to set our index fields before saving.
         batches_with_timestamps = []
         batches_with_addresses = []
-        timestamp = self.msg['timestamp']
+        timestamp = format_vumi_date(self.msg['timestamp'])
         for batch_id in self.batches.keys():
             batches_with_timestamps.append(u"%s$%s" % (batch_id, timestamp))
             batches_with_addresses.append(
@@ -234,7 +235,7 @@ class MessageStore(object):
         The ``start_timestamp`` parameter is used for testing only.
         """
         if start_timestamp is None:
-            start_timestamp = datetime.utcnow().strftime(VUMI_DATE_FORMAT)
+            start_timestamp = format_vumi_date(datetime.utcnow())
         yield self.cache.clear_batch(batch_id)
         yield self.cache.batch_start(batch_id)
         yield self.reconcile_outbound_cache(batch_id, start_timestamp)

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -13,11 +13,32 @@ from vumi.utils import to_kwargs
 VUMI_DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 
+def format_vumi_date(timestamp):
+    """Format a datetime object using the Vumi date format.
+
+    :param datetime timestamp:
+        The datetime object to format.
+    :return str:
+        The timestamp formatted as a string.
+    """
+    return timestamp.strftime(VUMI_DATE_FORMAT)
+
+
+def parse_vumi_date(value):
+    """Parse a timestamp string in using the Vumi date format.
+
+    :param str value:
+        The string to parse.
+    :return datetime:
+        A datetime object representing the timestamp.
+    """
+    return datetime.strptime(value, VUMI_DATE_FORMAT)
+
+
 def date_time_decoder(json_object):
     for key, value in json_object.items():
         try:
-            json_object[key] = datetime.strptime(value,
-                    VUMI_DATE_FORMAT)
+            json_object[key] = parse_vumi_date(value)
         except ValueError:
             continue
         except TypeError:

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -25,7 +25,7 @@ def format_vumi_date(timestamp):
 
 
 def parse_vumi_date(value):
-    """Parse a timestamp string in using the Vumi date format.
+    """Parse a timestamp string using the Vumi date format.
 
     :param str value:
         The string to parse.
@@ -50,7 +50,7 @@ class JSONMessageEncoder(json.JSONEncoder):
     """A JSON encoder that is able to serialize datetime"""
     def default(self, obj):
         if isinstance(obj, datetime):
-            return obj.strftime(VUMI_DATE_FORMAT)
+            return format_vumi_date(obj)
         return super(JSONMessageEncoder, self).default(obj)
 
 

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -1,7 +1,67 @@
+from datetime import datetime
+import json
+
 from vumi.tests.utils import RegexMatcher, UTCNearNow
-from vumi.message import (Message, TransportMessage, TransportEvent,
-                          TransportUserMessage)
+from vumi.message import (
+    Message, TransportMessage, TransportEvent, TransportUserMessage,
+    format_vumi_date, parse_vumi_date, from_json, to_json)
 from vumi.tests.helpers import VumiTestCase
+
+
+class ModuleUtilityTest(VumiTestCase):
+
+    def test_parse_vumi_date(self):
+        self.assertEqual(
+            parse_vumi_date('2015-01-02 23:14:11.456000'),
+            datetime(2015, 1, 2, 23, 14, 11, microsecond=456000))
+
+    def test_format_vumi_date(self):
+        self.assertEqual(
+            format_vumi_date(
+                datetime(2015, 1, 2, 23, 14, 11, microsecond=456000)),
+            '2015-01-02 23:14:11.456000')
+        self.assertEqual(
+            format_vumi_date(
+                datetime(2015, 1, 2, 23, 14, 11, microsecond=0)),
+            '2015-01-02 23:14:11.000000')
+
+    def test_from_json(self):
+        data = {
+            'foo': 1,
+            'baz': {
+                'a': 'b',
+            }
+        }
+        self.assertEqual(from_json(json.dumps(data)), data)
+
+    def test_to_json(self):
+        data = {
+            'foo': 1,
+            'baz': {
+                'a': 'b',
+            }
+        }
+        self.assertEqual(json.loads(to_json(data)), data)
+
+    def test_to_json_supports_vumi_dates(self):
+        timestamp = datetime(
+            2015, 1, 2, 12, 01, 02, microsecond=134001)
+        data = {
+            'foo': timestamp,
+        }
+        self.assertEqual(json.loads(to_json(data)), {
+            'foo': '2015-01-02 12:01:02.134001',
+        })
+
+    def test_from_json_supports_vumi_dates(self):
+        timestamp = datetime(
+            2015, 1, 2, 12, 01, 02, microsecond=134002)
+        data = {
+            'foo': '2015-01-02 12:01:02.134002',
+        }
+        self.assertEqual(from_json(json.dumps(data)), {
+            'foo': timestamp,
+        })
 
 
 class MessageTest(VumiTestCase):


### PR DESCRIPTION
Currently they're formatted using ``str(msg['timestamp'])``.

See https://github.com/praekelt/vumi-go/issues/1201 for an example of the issues this causes.

Probably they should be formatted with the Vumi timestamp format.