### PR TITLE
More permissive timestamp parsing

### DIFF
--- a/vumi/components/message_store_cache.py
+++ b/vumi/components/message_store_cache.py
@@ -9,7 +9,7 @@ import time
 from twisted.internet.defer import returnValue
 
 from vumi.persist.redis_base import Manager
-from vumi.message import TransportEvent, VUMI_DATE_FORMAT
+from vumi.message import TransportEvent, parse_vumi_date
 from vumi.errors import VumiError
 
 
@@ -230,7 +230,7 @@ class MessageStoreCache(object):
         Return a timestamp value for a datetime value.
         """
         if isinstance(timestamp, basestring):
-            timestamp = datetime.strptime(timestamp, VUMI_DATE_FORMAT)
+            timestamp = parse_vumi_date(timestamp)
         return time.mktime(timestamp.timetuple())
 
     @Manager.calls_manager

--- a/vumi/components/message_store_resource.py
+++ b/vumi/components/message_store_resource.py
@@ -12,7 +12,7 @@ from vumi.components.message_formatters import JsonFormatter, CsvFormatter
 from vumi.config import (
     ConfigDict, ConfigText, ConfigServerEndpoint, ConfigInt,
     ServerEndpointFallback)
-from vumi.message import VUMI_DATE_FORMAT
+from vumi.message import format_vumi_date
 from vumi.persist.txriak_manager import TxRiakManager
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.transports.httprpc import httprpc
@@ -55,7 +55,7 @@ class MessageStoreProxyResource(Resource):
         [value] = request.args[argname]
         try:
             timestamp = iso8601.parse_date(value)
-            return timestamp.strftime(VUMI_DATE_FORMAT)
+            return format_vumi_date(timestamp)
         except iso8601.ParseError as e:
             raise ParameterError(
                 "Invalid '%s' parameter: %s" % (argname, str(e)))

--- a/vumi/components/tests/test_message_store.py
+++ b/vumi/components/tests/test_message_store.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.message import TransportEvent, VUMI_DATE_FORMAT
+from vumi.message import TransportEvent, format_vumi_date
 from vumi.tests.helpers import (
     VumiTestCase, MessageHelper, PersistenceHelper, import_skip)
 
@@ -587,7 +587,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_inbound_messages(batch_id, 10)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         first_page = yield self.store.batch_inbound_keys_with_timestamps(
@@ -610,7 +610,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_inbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_timestamps(
@@ -623,7 +623,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_inbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_timestamps(
@@ -636,7 +636,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_inbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_timestamps(
@@ -649,7 +649,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_inbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_timestamps(
@@ -662,7 +662,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_outbound_messages(batch_id, 10)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         first_page = yield self.store.batch_outbound_keys_with_timestamps(
@@ -685,7 +685,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_outbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_timestamps(
@@ -698,7 +698,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_outbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_timestamps(
@@ -711,7 +711,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_outbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_timestamps(
@@ -724,7 +724,7 @@ class TestMessageStore(TestMessageStoreBase):
         messages = yield self.create_outbound_messages(batch_id, 5)
         sorted_keys = sorted((msg['timestamp'], msg['message_id'])
                              for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT))
+        all_keys = [(key, format_vumi_date(timestamp))
                     for (timestamp, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_timestamps(
@@ -738,7 +738,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         first_page = yield self.store.batch_inbound_keys_with_addresses(
@@ -762,7 +762,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_addresses(
@@ -776,7 +776,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_addresses(
@@ -790,7 +790,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         index_page = yield self.store.batch_inbound_keys_with_addresses(
@@ -804,7 +804,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         first_page = yield self.store.batch_outbound_keys_with_addresses(
@@ -828,7 +828,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_addresses(
@@ -842,7 +842,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_addresses(
@@ -856,7 +856,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         index_page = yield self.store.batch_outbound_keys_with_addresses(
@@ -880,7 +880,7 @@ class TestMessageStore(TestMessageStoreBase):
             yield self.store.add_event(dr)
 
         mk_tuple = lambda e, status: (
-            e["event_id"], e["timestamp"].strftime(VUMI_DATE_FORMAT), status)
+            e["event_id"], format_vumi_date(e["timestamp"]), status)
 
         all_keys = [mk_tuple(ack, "ack")] + [
             mk_tuple(e, "delivery_report.%s" % (e["delivery_status"],))
@@ -944,7 +944,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         inbound_stats_1 = yield self.store.batch_inbound_stats(
@@ -979,7 +979,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         inbound_stats_1 = yield self.store.batch_inbound_stats(
@@ -1015,7 +1015,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['from_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         inbound_stats_1 = yield self.store.batch_inbound_stats(
@@ -1072,7 +1072,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         outbound_stats_1 = yield self.store.batch_outbound_stats(
@@ -1107,7 +1107,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         outbound_stats_1 = yield self.store.batch_outbound_stats(
@@ -1143,7 +1143,7 @@ class TestMessageStore(TestMessageStoreBase):
         sorted_keys = sorted(
             (msg['timestamp'], msg['to_addr'], msg['message_id'])
             for msg in messages)
-        all_keys = [(key, timestamp.strftime(VUMI_DATE_FORMAT), addr)
+        all_keys = [(key, format_vumi_date(timestamp), addr)
                     for (timestamp, addr, key) in sorted_keys]
 
         outbound_stats_1 = yield self.store.batch_outbound_stats(
@@ -1276,8 +1276,7 @@ class TestMessageStoreCache(TestMessageStoreBase):
 
         # We want one message newer than the start of the recon, and they're
         # ordered from newest to oldest.
-        start_timestamp = inbound_messages[1]["timestamp"].strftime(
-            VUMI_DATE_FORMAT)
+        start_timestamp = format_vumi_date(inbound_messages[1]["timestamp"])
 
         yield self.store.reconcile_cache(batch_id, start_timestamp)
 

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -11,6 +11,8 @@ from vumi.utils import to_kwargs
 
 # This is the date format we work with internally
 VUMI_DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+# Same as above, but without microseconds (for more permissive parsing).
+_VUMI_DATE_FORMAT_NO_MICROSECONDS = "%Y-%m-%d %H:%M:%S"
 
 
 def format_vumi_date(timestamp):
@@ -36,7 +38,7 @@ def parse_vumi_date(value):
     """
     date_format = VUMI_DATE_FORMAT
     if "." not in value:
-        date_format = date_format.split(".")[0]
+        date_format = _VUMI_DATE_FORMAT_NO_MICROSECONDS
     return datetime.strptime(value, date_format)
 
 

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -37,7 +37,9 @@ def parse_vumi_date(value):
         A datetime object representing the timestamp.
     """
     date_format = VUMI_DATE_FORMAT
-    if "." not in value:
+    # We only look at the last ten characters, because that's where the "."
+    # will be in a valid serialised timestamp with microseconds.
+    if "." not in value[-10:]:
         date_format = _VUMI_DATE_FORMAT_NO_MICROSECONDS
     return datetime.strptime(value, date_format)
 

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -27,12 +27,17 @@ def format_vumi_date(timestamp):
 def parse_vumi_date(value):
     """Parse a timestamp string using the Vumi date format.
 
+    Timestamps without microseconds are also parsed correctly.
+
     :param str value:
         The string to parse.
     :return datetime:
         A datetime object representing the timestamp.
     """
-    return datetime.strptime(value, VUMI_DATE_FORMAT)
+    date_format = VUMI_DATE_FORMAT
+    if "." not in value:
+        date_format = date_format.split(".")[0]
+    return datetime.strptime(value, date_format)
 
 
 def date_time_decoder(json_object):

--- a/vumi/persist/fields.py
+++ b/vumi/persist/fields.py
@@ -5,7 +5,7 @@
 import iso8601
 from datetime import datetime
 
-from vumi.message import VUMI_DATE_FORMAT
+from vumi.message import format_vumi_date, parse_vumi_date
 from vumi.utils import to_kwargs
 
 
@@ -248,10 +248,10 @@ class Timestamp(Field):
                               "iso8601 formatted string.")
 
     def custom_to_riak(self, value):
-        return value.strftime(VUMI_DATE_FORMAT)
+        return format_vumi_date(value)
 
     def custom_from_riak(self, value):
-        return datetime.strptime(value, VUMI_DATE_FORMAT)
+        return parse_vumi_date(value)
 
 
 class Json(Field):
@@ -276,10 +276,10 @@ class VumiMessageDescriptor(FieldDescriptor):
                 modelobj._riak_object.delete_data_field(key)
 
     def _timestamp_to_json(self, dt):
-        return dt.strftime(VUMI_DATE_FORMAT)
+        return format_vumi_date(dt)
 
     def _timestamp_from_json(self, value):
-        return datetime.strptime(value, VUMI_DATE_FORMAT)
+        return parse_vumi_date(value)
 
     def set_value(self, modelobj, msg):
         """Set the value associated with this descriptor."""

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -15,6 +15,14 @@ class ModuleUtilityTest(VumiTestCase):
             parse_vumi_date('2015-01-02 23:14:11.456000'),
             datetime(2015, 1, 2, 23, 14, 11, microsecond=456000))
 
+    def test_parse_vumi_date_no_microseconds(self):
+        """
+        We can parse a timestamp even if it has no microseconds.
+        """
+        self.assertEqual(
+            parse_vumi_date('2015-01-02 23:14:11'),
+            datetime(2015, 1, 2, 23, 14, 11, microsecond=0))
+
     def test_format_vumi_date(self):
         self.assertEqual(
             format_vumi_date(


### PR DESCRIPTION
`vumi.message.parse_vumi_date()` requires the date being parsed to have microseconds, but it's useful to parse dates without microseconds as well.