### PR TITLE
Decrement _in_progress counter when a consumer breaks

### DIFF
--- a/vumi/service.py
+++ b/vumi/service.py
@@ -55,7 +55,8 @@ class AmqpFactory(protocol.ReconnectingClientFactory):
         return self.amqp_client
 
     def clientConnectionFailed(self, connector, reason):
-        log.err("AmqpFactory connection failed (%s)" % (reason.getErrorMessage(),))
+        log.err("AmqpFactory connection failed (%s)" % (
+            reason.getErrorMessage(),))
         self.worker._amqp_connection_failed()
         self.amqp_client = None
         protocol.ReconnectingClientFactory.clientConnectionFailed(
@@ -65,7 +66,8 @@ class AmqpFactory(protocol.ReconnectingClientFactory):
         if not self.worker.running:
             # We've specifically asked for this disconnect.
             return
-        log.err("AmqpFactory client connection lost (%s)" % (reason.getErrorMessage(),))
+        log.err("AmqpFactory client connection lost (%s)" % (
+            reason.getErrorMessage(),))
         self.worker._amqp_connection_failed()
         self.amqp_client = None
         protocol.ReconnectingClientFactory.clientConnectionLost(
@@ -223,8 +225,8 @@ class Worker(MultiService, object):
                    exchange_name='vumi', exchange_type='direct', durable=True,
                    delivery_mode=2):
         class_name = self.routing_key_to_class_name(routing_key)
-        publisher_class = type("%sDynamicPublisher" % class_name, (Publisher,),
-            {
+        publisher_class = type(
+            "%sDynamicPublisher" % class_name, (Publisher,), {
                 "routing_key": routing_key,
                 "exchange_name": exchange_name,
                 "exchange_type": exchange_type,
@@ -418,8 +420,8 @@ class Publisher(object):
 
     def publish_raw(self, data, **kwargs):
         amq_message = Content(data)
-        amq_message['delivery mode'] = kwargs.pop('delivery_mode',
-                self.delivery_mode)
+        amq_message['delivery mode'] = kwargs.pop(
+            'delivery_mode', self.delivery_mode)
         return self.publish(amq_message, **kwargs)
 
 

--- a/vumi/tests/test_service.py
+++ b/vumi/tests/test_service.py
@@ -87,7 +87,8 @@ class TestService(VumiTestCase):
         yield self.worker_helper.kick_delivery()
         # If we get here without timing out, everything should be happy.
         self.assertEqual(consumer._in_progress, 0)
-        self.flushLoggedErrors()
+        [failure] = self.flushLoggedErrors()
+        self.assertEqual(failure.getErrorMessage(), "oops")
 
     @inlineCallbacks
     def test_start_publisher(self):

--- a/vumi/tests/test_service.py
+++ b/vumi/tests/test_service.py
@@ -1,7 +1,7 @@
 import json
 from collections import namedtuple
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, Deferred
 
 from vumi.message import Message
 from vumi.service import Worker, WorkerCreator
@@ -55,6 +55,39 @@ class TestService(VumiTestCase):
             'test.routing.key', lambda msg: log.append(msg), prefetch_count=10)
         self.assertEqual(10, consumer.channel._get_consumer_prefetch(
             consumer._consumer_tag))
+
+    @inlineCallbacks
+    def test_broken_consume(self):
+        """
+        If a consumer function throws an exception, we still decrement the
+        progress counter.
+        """
+        worker = yield self.worker_helper.get_worker(Worker, {}, start=False)
+        start_d = Deferred()
+        pause_d = Deferred()
+
+        @inlineCallbacks
+        def consume_func(msg):
+            start_d.callback(None)
+            yield pause_d
+            raise Exception("oops")
+
+        consumer = yield worker.consume('test.routing.key', consume_func)
+        message = fake_amq_message({"key": "value"})
+
+        # Assert we have no messages being processed and publish a message.
+        self.assertEqual(consumer._in_progress, 0)
+        self.worker_helper.broker.basic_publish(
+            'vumi', 'test.routing.key', message.content)
+        # Wait for the processing to start and assert that it's in progress.
+        yield start_d
+        self.assertEqual(consumer._in_progress, 1)
+        # Unpause the processing and wait for it to finish.
+        pause_d.callback(None)
+        yield self.worker_helper.kick_delivery()
+        # If we get here without timing out, everything should be happy.
+        self.assertEqual(consumer._in_progress, 0)
+        self.flushLoggedErrors()
 
     @inlineCallbacks
     def test_start_publisher(self):


### PR DESCRIPTION
The consumer in ``vumi.service`` maintains an ``_in_progress`` counter to track how many messages are currently being handled. If processing a message raises an exception, that will prevent the worker with the broken consumer from shutting down cleaning because it'll keep waiting for ``_in_progress`` to reach zero.