### PR TITLE
Allow the session length middleware's redis key namespace to be configurable

### DIFF
--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -19,6 +19,11 @@ class SessionLengthMiddlewareConfig(BaseMiddlewareConfig):
     timeout = ConfigInt(
         "Redis key timeout (secs)",
         default=600, static=True)
+    key_namespace = ConfigText(
+        "Namespace to use to lookup and set the (address, timestamp) "
+        "key-value pairs in redis. In none is given, the middleware will use "
+        "the `transport_name` message field instead.",
+        default=None, static=True)
     field_name = ConfigText(
         "Field name in message helper_metadata",
         default="session", static=True)
@@ -57,6 +62,7 @@ class SessionLengthMiddleware(BaseMiddleware):
     def setup_middleware(self):
         self.redis = yield TxRedisManager.from_config(
             self.config.redis_manager)
+        self.key_namespace = self.config.key_namespace
         self.timeout = self.config.timeout
         self.field_name = self.config.field_name
         self.clock = reactor
@@ -69,7 +75,10 @@ class SessionLengthMiddleware(BaseMiddleware):
         return self.clock.seconds()
 
     def _key_namespace(self, message):
-        return message.get('transport_name')
+        if self.key_namespace is not None:
+            return self.key_namespace
+        else:
+            return message.get('transport_name')
 
     def _key_address(self, message, direction):
         if direction == self.DIRECTION_INBOUND:

--- a/vumi/middleware/tests/test_session_length.py
+++ b/vumi/middleware/tests/test_session_length.py
@@ -19,11 +19,10 @@ class TestSessionLengthMiddleware(VumiTestCase):
         self.clock = Clock()
 
     @inlineCallbacks
-    def mk_middleware(self, config={}):
+    def mk_middleware(self, **kw):
         dummy_worker = object()
-        config = self.persistence_helper.mk_config(config)
-        mw = SessionLengthMiddleware(
-            "session_length", config, dummy_worker)
+        config = self.persistence_helper.mk_config(kw)
+        mw = SessionLengthMiddleware("session_length", config, dummy_worker)
         yield mw.setup_middleware()
         self.patch(mw, 'clock', self.clock)
         self.redis = mw.redis
@@ -34,7 +33,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
                session_start=None, session_end=None):
         msg = TransportUserMessage(
             to_addr=to_addr, from_addr=from_addr,
-            transport_name="dummy_connector",
+            transport_name="dummy_transport",
             transport_type="dummy_transport_type",
             session_event=session_event)
 
@@ -56,8 +55,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_start = self.mk_msg('+12345', '+54321')
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+54321:session_created')
-        self.assertTrue(value is not None)
+        value = yield self.redis.get('dummy_transport:+54321:session_created')
+        self.assertEqual(value, '0.0')
         self.assertEqual(
                 msg['helper_metadata']['session']['session_start'], 0.0)
 
@@ -77,14 +76,15 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+54321:session_created')
-        self.assertTrue(value is not None)
+        value = yield self.redis.get('dummy_transport:+54321:session_created')
+        self.assertEqual(value, '0.0')
+
         self.assertEqual(
                 msg['helper_metadata']['session']['session_start'], 0.0)
 
         self.clock.advance(1.0)
         msg = yield mw.handle_inbound(msg_end, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+54321:session_created')
+        value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertTrue(value is None)
         self.assertEqual(
                 msg['helper_metadata']['session']['session_start'], 0.0)
@@ -95,16 +95,16 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_start_no_overwrite(self):
         mw = yield self.mk_middleware()
 
-        msg_start = self.mk_msg(
+        msg = self.mk_msg(
             '+12345',
             '+54321',
             session_start=23,
             session_event=SESSION_NEW)
 
-        yield self.redis.set('dummy_connector:+12345:session_created', '23')
+        yield self.redis.set('dummy_transport:+12345:session_created', '23')
 
-        msg = yield mw.handle_inbound(msg_start, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+12345:session_created')
+        msg = yield mw.handle_inbound(msg, "dummy_connector")
+        value = yield self.redis.get('dummy_transport:+12345:session_created')
         self.assertEqual(value, '23')
 
         self.assertEqual(
@@ -114,14 +114,14 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_end_no_overwrite(self):
         mw = yield self.mk_middleware()
 
-        msg_start = self.mk_msg(
+        msg = self.mk_msg(
             '+12345',
             '+54321',
             session_start=23,
             session_end=32,
             session_event=SESSION_CLOSE)
 
-        msg = yield mw.handle_inbound(msg_start, "dummy_connector")
+        msg = yield mw.handle_inbound(msg, "dummy_connector")
 
         self.assertEqual(
             msg['helper_metadata']['session']['session_start'], 23)
@@ -133,13 +133,13 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_none_no_overwrite(self):
         mw = yield self.mk_middleware()
 
-        msg_start = self.mk_msg(
+        msg = self.mk_msg(
             '+12345',
             '+54321',
             session_start=23,
             session_event=SESSION_NONE)
 
-        msg = yield mw.handle_inbound(msg_start, "dummy_connector")
+        msg = yield mw.handle_inbound(msg, "dummy_connector")
 
         self.assertEqual(
             msg['helper_metadata']['session']['session_start'], 23)
@@ -150,8 +150,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_start = self.mk_msg('+12345', '+54321')
 
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+12345:session_created')
-        self.assertTrue(value is not None)
+        value = yield self.redis.get('dummy_transport:+12345:session_created')
+        self.assertEqual(value, '0.0')
         self.assertEqual(
                 msg['helper_metadata']['session']['session_start'], 0.0)
 
@@ -171,14 +171,14 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+12345:session_created')
-        self.assertTrue(value is not None)
+        value = yield self.redis.get('dummy_transport:+12345:session_created')
+        self.assertEqual(value, '0.0')
         self.assertEqual(
                 msg['helper_metadata']['session']['session_start'], 0.0)
 
         self.clock.advance(1.0)
         msg = yield mw.handle_outbound(msg_end, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+54321:session_created')
+        value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertTrue(value is None)
         self.assertEqual(
                 msg['helper_metadata']['session']['session_start'], 0.0)
@@ -189,16 +189,16 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_start_no_overwrite(self):
         mw = yield self.mk_middleware()
 
-        msg_start = self.mk_msg(
+        msg = self.mk_msg(
             '+12345',
             '+54321',
             session_start=23,
             session_event=SESSION_NEW)
 
-        yield self.redis.set('dummy_connector:+12345:session_created', '23')
+        yield self.redis.set('dummy_transport:+12345:session_created', '23')
 
-        msg = yield mw.handle_outbound(msg_start, "dummy_connector")
-        value = yield self.redis.get('dummy_connector:+12345:session_created')
+        msg = yield mw.handle_outbound(msg, "dummy_connector")
+        value = yield self.redis.get('dummy_transport:+12345:session_created')
         self.assertEqual(value, '23')
 
         self.assertEqual(
@@ -208,14 +208,14 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_end_no_overwrite(self):
         mw = yield self.mk_middleware()
 
-        msg_start = self.mk_msg(
+        msg = self.mk_msg(
             '+12345',
             '+54321',
             session_start=23,
             session_end=32,
             session_event=SESSION_CLOSE)
 
-        msg = yield mw.handle_outbound(msg_start, "dummy_connector")
+        msg = yield mw.handle_outbound(msg, "dummy_connector")
 
         self.assertEqual(
             msg['helper_metadata']['session']['session_start'], 23)
@@ -227,13 +227,13 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_none_no_overwrite(self):
         mw = yield self.mk_middleware()
 
-        msg_start = self.mk_msg(
+        msg = self.mk_msg(
             '+12345',
             '+54321',
             session_start=23,
             session_event=SESSION_NONE)
 
-        msg = yield mw.handle_outbound(msg_start, "dummy_connector")
+        msg = yield mw.handle_outbound(msg, "dummy_connector")
 
         self.assertEqual(
             msg['helper_metadata']['session']['session_start'], 23)
@@ -244,23 +244,23 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_start = self.mk_msg('+12345', '+54321')
 
         yield mw.handle_inbound(msg_start, "dummy_connector")
-        ttl = yield self.redis.ttl('dummy_connector::+54321:session_created')
+        ttl = yield self.redis.ttl('dummy_transport::+54321:session_created')
         self.assertTrue(ttl <= 120)
 
     @inlineCallbacks
     def test_redis_key_custom_timeout(self):
-        mw = yield self.mk_middleware({'timeout': 20})
+        mw = yield self.mk_middleware(timeout=20)
         msg_start = self.mk_msg('+12345', '+54321')
 
         yield mw.handle_inbound(msg_start, "dummy_connector")
-        ttl = yield self.redis.ttl('dummy_connector:+54321:session_created')
+        ttl = yield self.redis.ttl('dummy_transport:+54321:session_created')
         self.assertTrue(ttl <= 20)
 
     @inlineCallbacks
     def test_custom_message_field_name(self):
-        mw = yield self.mk_middleware({'field_name': 'foobar'})
+        mw = yield self.mk_middleware(field_name='foobar')
         msg_start = self.mk_msg('+12345', '+54321')
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
-        self.assertTrue(
-            msg['helper_metadata']['foobar']['session_start'] is not None)
+        self.assertEqual(
+            msg['helper_metadata']['foobar']['session_start'], 0.0)


### PR DESCRIPTION
At the moment, the session length middleware uses the message's `transport_name` to namespace the address-timestamp key-value pairs in redis. When we put the session length middleware on load balanced transports, the redis key used for start-of-session inbound messages is the actual transport name, not the exposed transport name rewritten by the load balancer (since the middleware sees the messages before the load balancer does).

One way around this is to allow the middleware's namespace to be configurable, and default to the message's `transport_name`.