### PR TITLE
Better handling of Redis connections in tests

### DIFF
--- a/vumi/persist/tests/test_redis_manager.py
+++ b/vumi/persist/tests/test_redis_manager.py
@@ -62,6 +62,8 @@ class TestRedisManager(VumiTestCase):
             'key%d' % i for i in range(10)))
 
     def test_ttl(self):
+        # FIXME: Real Redis returns -1 for missing TTLs and -1 or -2 (depending
+        #        on version) for missing keys.
         missing_ttl = self.manager.ttl("missing_key")
         self.assertEqual(missing_ttl, None)
 

--- a/vumi/persist/tests/test_redis_manager.py
+++ b/vumi/persist/tests/test_redis_manager.py
@@ -62,8 +62,6 @@ class TestRedisManager(VumiTestCase):
             'key%d' % i for i in range(10)))
 
     def test_ttl(self):
-        # FIXME: Real Redis returns -1 for missing TTLs and -1 or -2 (depending
-        #        on version) for missing keys.
         missing_ttl = self.manager.ttl("missing_key")
         self.assertEqual(missing_ttl, None)
 

--- a/vumi/tests/helpers.py
+++ b/vumi/tests/helpers.py
@@ -1392,7 +1392,6 @@ class PersistenceHelper(object):
             # Ignore managers that are already closed.
             if e.args[0] != 'Not connected':
                 raise
-        yield manager.close_manager()
 
     def _check_patches_applied(self):
         if not self._patches_applied:

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -1813,7 +1813,7 @@ class TestPersistenceHelper(VumiTestCase):
 
     def test__purge_redis(self):
         """
-        ._purge_redis() should call manager._purge_all() and disconnect.
+        ._purge_redis() should call manager._purge_all() and remain connected.
         """
         persistence_helper = PersistenceHelper()
         manager = FakeRedisManagerForCleanup('prefix1')
@@ -1821,7 +1821,7 @@ class TestPersistenceHelper(VumiTestCase):
         self.assertEqual(manager.connected, True)
         success_result_of(persistence_helper._purge_redis(manager))
         self.assertEqual(manager.purged, True)
-        self.assertEqual(manager.connected, False)
+        self.assertEqual(manager.connected, True)
 
     def test__purge_redis_not_connected(self):
         """


### PR DESCRIPTION
If we have multiple Redis connections in a test, we sometimes get errors during cleanup.