### PR TITLE
Session middleware breaks when to_addr is None for an outbound message.

### DIFF
--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -166,7 +166,6 @@ class SessionLengthMiddleware(BaseMiddleware):
                 "Session length redis namespace cannot be None, "
                 "skipping message")
             returnValue(message)
-            return
 
         key_addr = self._key_address(message, direction)
         if key_addr is None:

--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -162,9 +162,9 @@ class SessionLengthMiddleware(BaseMiddleware):
     def _process_message(self, message, direction):
         namespace = self.namespace_handler(message)
         if namespace is None:
-            log.warning(
+            log.error(SessionLengthMiddlewareError(
                 "Session length redis namespace cannot be None, "
-                "skipping message")
+                "skipping message"))
             returnValue(message)
 
         key_addr = self._key_address(message, direction)

--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -6,10 +6,17 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet import reactor
 
 from vumi import log
+from vumi.errors import VumiError
 from vumi.message import TransportUserMessage
 from vumi.middleware.base import BaseMiddleware, BaseMiddlewareConfig
 from vumi.middleware.tagger import TaggingMiddleware
 from vumi.persist.txredis_manager import TxRedisManager
+
+
+class SessionLengthMiddlewareError(VumiError):
+    """
+    Raised when the SessionLengthMiddleware encounters unexcepted messages.
+    """
 
 
 class SessionLengthMiddlewareConfig(BaseMiddlewareConfig):
@@ -162,6 +169,12 @@ class SessionLengthMiddleware(BaseMiddleware):
                 "skipping message")
             returnValue(message)
             return
+
+        if self._key_address(message, direction) is None:
+            log.error(SessionLengthMiddlewareError(
+                "Session length key address cannot be None, "
+                "skipping message"))
+            returnValue(message)
 
         redis_key = self._key(message, direction)
 

--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -99,9 +99,9 @@ class SessionLengthMiddleware(BaseMiddleware):
 
     def _key_address(self, message, direction):
         if direction == self.DIRECTION_INBOUND:
-            return message['from_addr']
-        elif direction == self.DIRECTION_OUTBOUND:
             return message['to_addr']
+        elif direction == self.DIRECTION_OUTBOUND:
+            return message['from_addr']
 
     def _key(self, message, direction):
         return ':'.join((
@@ -161,7 +161,6 @@ class SessionLengthMiddleware(BaseMiddleware):
                 "Session length redis namespace cannot be None, "
                 "skipping message")
             returnValue(message)
-            return
 
         redis_key = self._key(message, direction)
 

--- a/vumi/middleware/session_length.py
+++ b/vumi/middleware/session_length.py
@@ -99,9 +99,9 @@ class SessionLengthMiddleware(BaseMiddleware):
 
     def _key_address(self, message, direction):
         if direction == self.DIRECTION_INBOUND:
-            return message['to_addr']
-        elif direction == self.DIRECTION_OUTBOUND:
             return message['from_addr']
+        elif direction == self.DIRECTION_OUTBOUND:
+            return message['to_addr']
 
     def _key(self, message, direction):
         return ':'.join((
@@ -161,6 +161,7 @@ class SessionLengthMiddleware(BaseMiddleware):
                 "Session length redis namespace cannot be None, "
                 "skipping message")
             returnValue(message)
+            return
 
         redis_key = self._key(message, direction)
 

--- a/vumi/middleware/tests/test_session_length.py
+++ b/vumi/middleware/tests/test_session_length.py
@@ -58,7 +58,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_start(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+54321', '+12345')
+        msg_start = self.mk_msg('+12345', '+54321')
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
@@ -70,7 +70,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_end(self):
         mw = yield self.mk_middleware()
-        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
+        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_inbound(msg_end, "dummy_connector")
         self.assertEqual(
@@ -79,22 +79,22 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_start_end(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+54321', '+12345')
-        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
+        msg_start = self.mk_msg('+12345', '+54321')
+        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertEqual(value, '0.0')
 
         self.assertEqual(
-            msg['helper_metadata']['session']['session_start'], 0.0)
+                msg['helper_metadata']['session']['session_start'], 0.0)
 
         self.clock.advance(1.0)
         msg = yield mw.handle_inbound(msg_end, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertTrue(value is None)
         self.assertEqual(
-            msg['helper_metadata']['session']['session_start'], 0.0)
+                msg['helper_metadata']['session']['session_start'], 0.0)
         self.assertEqual(
             msg['helper_metadata']['session']['session_end'], 1.0)
 
@@ -103,8 +103,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_start=23,
             session_event=SESSION_NEW)
 
@@ -122,8 +122,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_start=23.0,
             session_end=32.0,
             session_event=SESSION_CLOSE)
@@ -141,8 +141,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_start=23.0,
             session_event=SESSION_NONE)
 
@@ -155,7 +155,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_start_transport_namespace_type(self):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
-        msg = self.mk_msg('+54321', '+12345', transport_name='foo')
+        msg = self.mk_msg('+12345', '+54321', transport_name='foo')
         msg = yield mw.handle_inbound(msg, "dummy_connector")
 
         value = yield self.redis.get('foo:+54321:session_created')
@@ -170,8 +170,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('foo:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             transport_name='foo')
 
@@ -192,8 +192,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('foo:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             transport_name='foo')
 
@@ -205,7 +205,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_start_no_transport_name(self):
         mw = yield self.mk_middleware(namespace_type='transport_name')
-        msg = self.mk_msg('+54321', '+12345', transport_name=None)
+        msg = self.mk_msg('+12345', '+54321', transport_name=None)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -221,8 +221,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             transport_name=None)
 
@@ -240,8 +240,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_NONE,
             transport_name=None)
 
@@ -258,7 +258,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_start_tag_namespace_type(self):
         mw = yield self.mk_middleware(namespace_type='tag')
 
-        msg = self.mk_msg('+54321', '+12345', tag=('pool1', 'tag1'))
+        msg = self.mk_msg('+12345', '+54321', tag=('pool1', 'tag1'))
         msg = yield mw.handle_inbound(msg, "dummy_connector")
 
         value = yield self.redis.get('pool1:tag1:+54321:session_created')
@@ -273,8 +273,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             tag=('pool1', 'tag1'))
 
@@ -295,8 +295,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             tag=('pool1', 'tag1'))
 
@@ -310,7 +310,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+54321', '+12345')
+        msg = self.mk_msg('+12345', '+54321')
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -326,7 +326,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
+        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -343,7 +343,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         # create message with no tag
-        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_NONE)
+        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_NONE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -357,41 +357,41 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_outgoing_message_session_start(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+54321', '+12345')
+        msg_start = self.mk_msg('+12345', '+54321')
 
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+12345:session_created')
         self.assertEqual(value, '0.0')
         self.assertEqual(
-            msg['helper_metadata']['session']['session_start'], 0.0)
+                msg['helper_metadata']['session']['session_start'], 0.0)
 
     @inlineCallbacks
     def test_outgoing_message_session_end(self):
         mw = yield self.mk_middleware()
-        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
+        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_outbound(msg_end, "dummy_connector")
         self.assertEqual(
-            msg['helper_metadata']['session']['session_end'], 0.0)
+                msg['helper_metadata']['session']['session_end'], 0.0)
 
     @inlineCallbacks
     def test_outgoing_message_session_start_end(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+54321', '+12345')
-        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
+        msg_start = self.mk_msg('+12345', '+54321')
+        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+12345:session_created')
         self.assertEqual(value, '0.0')
         self.assertEqual(
-            msg['helper_metadata']['session']['session_start'], 0.0)
+                msg['helper_metadata']['session']['session_start'], 0.0)
 
         self.clock.advance(1.0)
         msg = yield mw.handle_outbound(msg_end, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertTrue(value is None)
         self.assertEqual(
-            msg['helper_metadata']['session']['session_start'], 0.0)
+                msg['helper_metadata']['session']['session_start'], 0.0)
         self.assertEqual(
             msg['helper_metadata']['session']['session_end'], 1.0)
 
@@ -400,8 +400,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_start=23,
             session_event=SESSION_NEW)
 
@@ -419,8 +419,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_start=23,
             session_end=32,
             session_event=SESSION_CLOSE)
@@ -438,8 +438,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_start=23,
             session_event=SESSION_NONE)
 
@@ -452,7 +452,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_start_no_transport_name(self):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
-        msg = self.mk_msg('+54321', '+12345', transport_name=None)
+        msg = self.mk_msg('+12345', '+54321', transport_name=None)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -468,8 +468,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             transport_name=None)
 
@@ -487,8 +487,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_NONE,
             transport_name=None)
 
@@ -505,7 +505,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_start_tag_namespace_type(self):
         mw = yield self.mk_middleware(namespace_type='tag')
 
-        msg = self.mk_msg('+54321', '+12345', tag=('pool1', 'tag1'))
+        msg = self.mk_msg('+12345', '+54321', tag=('pool1', 'tag1'))
         msg = yield mw.handle_outbound(msg, "dummy_connector")
 
         value = yield self.redis.get('pool1:tag1:+12345:session_created')
@@ -520,8 +520,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+12345:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_CLOSE,
             tag=('pool1', 'tag1'))
 
@@ -542,8 +542,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+12345:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+54321',
             '+12345',
+            '+54321',
             session_event=SESSION_NONE,
             tag=('pool1', 'tag1'))
 
@@ -557,7 +557,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+54321', '+12345')
+        msg = self.mk_msg('+12345', '+54321')
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -573,7 +573,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
+        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -590,7 +590,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         # create message with no tag
-        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_NONE)
+        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_NONE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -604,7 +604,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_redis_key_timeout(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+54321', '+12345')
+        msg_start = self.mk_msg('+12345', '+54321')
 
         yield mw.handle_inbound(msg_start, "dummy_connector")
         ttl = yield self.redis.ttl('dummy_transport::+54321:session_created')
@@ -613,7 +613,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_redis_key_custom_timeout(self):
         mw = yield self.mk_middleware(timeout=20)
-        msg_start = self.mk_msg('+54321', '+12345')
+        msg_start = self.mk_msg('+12345', '+54321')
 
         yield mw.handle_inbound(msg_start, "dummy_connector")
         ttl = yield self.redis.ttl('dummy_transport:+54321:session_created')
@@ -622,7 +622,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_custom_message_field_name(self):
         mw = yield self.mk_middleware(field_name='foobar')
-        msg_start = self.mk_msg('+54321', '+12345')
+        msg_start = self.mk_msg('+12345', '+54321')
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         self.assertEqual(

--- a/vumi/middleware/tests/test_session_length.py
+++ b/vumi/middleware/tests/test_session_length.py
@@ -56,6 +56,10 @@ class TestSessionLengthMiddleware(VumiTestCase):
         metadata = msg['helper_metadata'].setdefault(metadata_field_name, {})
         metadata[name] = value
 
+    def assert_middleware_error(self, msg):
+        [err] = self.flushLoggedErrors(SessionLengthMiddlewareError)
+        self.assertEqual(str(err.value), msg)
+
     @inlineCallbacks
     def test_incoming_message_session_start(self):
         mw = yield self.mk_middleware()
@@ -208,11 +212,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
         msg = self.mk_msg('+12345', '+54321', transport_name=None)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_inbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_inbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -227,11 +229,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
             session_event=SESSION_CLOSE,
             transport_name=None)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_inbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_inbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -246,11 +246,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
             session_event=SESSION_NONE,
             transport_name=None)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_inbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_inbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -313,11 +311,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         # create message with no tag
         msg = self.mk_msg('+12345', '+54321')
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_inbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_inbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -329,11 +325,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         # create message with no tag
         msg = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_inbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_inbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -346,11 +340,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         # create message with no tag
         msg = self.mk_msg('+12345', '+54321', session_event=SESSION_NONE)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_inbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_inbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -455,11 +447,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
 
         msg = self.mk_msg('+12345', '+54321', transport_name=None)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_outbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_outbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -474,11 +464,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
             session_event=SESSION_CLOSE,
             transport_name=None)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_outbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_outbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -493,11 +481,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
             session_event=SESSION_NONE,
             transport_name=None)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_outbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_outbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -560,11 +546,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         # create message with no tag
         msg = self.mk_msg('+12345', '+54321')
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_outbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_outbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -576,11 +560,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         # create message with no tag
         msg = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_outbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_outbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -593,11 +575,9 @@ class TestSessionLengthMiddleware(VumiTestCase):
         # create message with no tag
         msg = self.mk_msg('+12345', '+54321', session_event=SESSION_NONE)
 
-        with LogCatcher() as lc:
-            result_msg = yield mw.handle_outbound(msg, "dummy_connector")
-
-        self.assertEqual(lc.messages(), [
-            "Session length redis namespace cannot be None, skipping message"])
+        result_msg = yield mw.handle_outbound(msg, "dummy_connector")
+        self.assert_middleware_error(
+            "Session length redis namespace cannot be None, skipping message")
 
         self.assertEqual(msg, result_msg)
         self.assertTrue('session' not in msg['helper_metadata'])
@@ -635,9 +615,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_start = self.mk_msg('+12345', None)
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         self.assertEqual(msg, msg_start)
-        [err] = self.flushLoggedErrors(SessionLengthMiddlewareError)
-        self.assertEqual(
-            str(err.value),
+        self.assert_middleware_error(
             "Session length key address cannot be None, skipping message")
 
     @inlineCallbacks
@@ -646,7 +624,5 @@ class TestSessionLengthMiddleware(VumiTestCase):
         msg_start = self.mk_msg(None, '+54321')
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
         self.assertEqual(msg, msg_start)
-        [err] = self.flushLoggedErrors(SessionLengthMiddlewareError)
-        self.assertEqual(
-            str(err.value),
+        self.assert_middleware_error(
             "Session length key address cannot be None, skipping message")

--- a/vumi/middleware/tests/test_session_length.py
+++ b/vumi/middleware/tests/test_session_length.py
@@ -58,7 +58,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_start(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+12345', '+54321')
+        msg_start = self.mk_msg('+54321', '+12345')
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
@@ -70,7 +70,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_end(self):
         mw = yield self.mk_middleware()
-        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
+        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_inbound(msg_end, "dummy_connector")
         self.assertEqual(
@@ -79,22 +79,22 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_start_end(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+12345', '+54321')
-        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
+        msg_start = self.mk_msg('+54321', '+12345')
+        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertEqual(value, '0.0')
 
         self.assertEqual(
-                msg['helper_metadata']['session']['session_start'], 0.0)
+            msg['helper_metadata']['session']['session_start'], 0.0)
 
         self.clock.advance(1.0)
         msg = yield mw.handle_inbound(msg_end, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertTrue(value is None)
         self.assertEqual(
-                msg['helper_metadata']['session']['session_start'], 0.0)
+            msg['helper_metadata']['session']['session_start'], 0.0)
         self.assertEqual(
             msg['helper_metadata']['session']['session_end'], 1.0)
 
@@ -103,8 +103,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_start=23,
             session_event=SESSION_NEW)
 
@@ -122,8 +122,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_start=23.0,
             session_end=32.0,
             session_event=SESSION_CLOSE)
@@ -141,8 +141,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_start=23.0,
             session_event=SESSION_NONE)
 
@@ -155,7 +155,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_start_transport_namespace_type(self):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
-        msg = self.mk_msg('+12345', '+54321', transport_name='foo')
+        msg = self.mk_msg('+54321', '+12345', transport_name='foo')
         msg = yield mw.handle_inbound(msg, "dummy_connector")
 
         value = yield self.redis.get('foo:+54321:session_created')
@@ -170,8 +170,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('foo:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             transport_name='foo')
 
@@ -192,8 +192,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('foo:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             transport_name='foo')
 
@@ -205,7 +205,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_incoming_message_session_start_no_transport_name(self):
         mw = yield self.mk_middleware(namespace_type='transport_name')
-        msg = self.mk_msg('+12345', '+54321', transport_name=None)
+        msg = self.mk_msg('+54321', '+12345', transport_name=None)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -221,8 +221,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             transport_name=None)
 
@@ -240,8 +240,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_NONE,
             transport_name=None)
 
@@ -258,7 +258,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_incoming_message_session_start_tag_namespace_type(self):
         mw = yield self.mk_middleware(namespace_type='tag')
 
-        msg = self.mk_msg('+12345', '+54321', tag=('pool1', 'tag1'))
+        msg = self.mk_msg('+54321', '+12345', tag=('pool1', 'tag1'))
         msg = yield mw.handle_inbound(msg, "dummy_connector")
 
         value = yield self.redis.get('pool1:tag1:+54321:session_created')
@@ -273,8 +273,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             tag=('pool1', 'tag1'))
 
@@ -295,8 +295,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             tag=('pool1', 'tag1'))
 
@@ -310,7 +310,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+12345', '+54321')
+        msg = self.mk_msg('+54321', '+12345')
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -326,7 +326,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
+        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -343,7 +343,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         # create message with no tag
-        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_NONE)
+        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_NONE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_inbound(msg, "dummy_connector")
@@ -357,41 +357,41 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_outgoing_message_session_start(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+12345', '+54321')
+        msg_start = self.mk_msg('+54321', '+12345')
 
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+12345:session_created')
         self.assertEqual(value, '0.0')
         self.assertEqual(
-                msg['helper_metadata']['session']['session_start'], 0.0)
+            msg['helper_metadata']['session']['session_start'], 0.0)
 
     @inlineCallbacks
     def test_outgoing_message_session_end(self):
         mw = yield self.mk_middleware()
-        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
+        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_outbound(msg_end, "dummy_connector")
         self.assertEqual(
-                msg['helper_metadata']['session']['session_end'], 0.0)
+            msg['helper_metadata']['session']['session_end'], 0.0)
 
     @inlineCallbacks
     def test_outgoing_message_session_start_end(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+12345', '+54321')
-        msg_end = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
+        msg_start = self.mk_msg('+54321', '+12345')
+        msg_end = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
 
         msg = yield mw.handle_outbound(msg_start, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+12345:session_created')
         self.assertEqual(value, '0.0')
         self.assertEqual(
-                msg['helper_metadata']['session']['session_start'], 0.0)
+            msg['helper_metadata']['session']['session_start'], 0.0)
 
         self.clock.advance(1.0)
         msg = yield mw.handle_outbound(msg_end, "dummy_connector")
         value = yield self.redis.get('dummy_transport:+54321:session_created')
         self.assertTrue(value is None)
         self.assertEqual(
-                msg['helper_metadata']['session']['session_start'], 0.0)
+            msg['helper_metadata']['session']['session_start'], 0.0)
         self.assertEqual(
             msg['helper_metadata']['session']['session_end'], 1.0)
 
@@ -400,8 +400,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_start=23,
             session_event=SESSION_NEW)
 
@@ -419,8 +419,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_start=23,
             session_end=32,
             session_event=SESSION_CLOSE)
@@ -438,8 +438,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware()
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_start=23,
             session_event=SESSION_NONE)
 
@@ -452,7 +452,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_start_no_transport_name(self):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
-        msg = self.mk_msg('+12345', '+54321', transport_name=None)
+        msg = self.mk_msg('+54321', '+12345', transport_name=None)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -468,8 +468,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             transport_name=None)
 
@@ -487,8 +487,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='transport_name')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_NONE,
             transport_name=None)
 
@@ -505,7 +505,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     def test_outgoing_message_session_start_tag_namespace_type(self):
         mw = yield self.mk_middleware(namespace_type='tag')
 
-        msg = self.mk_msg('+12345', '+54321', tag=('pool1', 'tag1'))
+        msg = self.mk_msg('+54321', '+12345', tag=('pool1', 'tag1'))
         msg = yield mw.handle_outbound(msg, "dummy_connector")
 
         value = yield self.redis.get('pool1:tag1:+12345:session_created')
@@ -520,8 +520,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+12345:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_CLOSE,
             tag=('pool1', 'tag1'))
 
@@ -542,8 +542,8 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+12345:session_created', '23.0')
 
         msg = self.mk_msg(
-            '+12345',
             '+54321',
+            '+12345',
             session_event=SESSION_NONE,
             tag=('pool1', 'tag1'))
 
@@ -557,7 +557,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+12345', '+54321')
+        msg = self.mk_msg('+54321', '+12345')
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -573,7 +573,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         mw = yield self.mk_middleware(namespace_type='tag')
 
         # create message with no tag
-        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_CLOSE)
+        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_CLOSE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -590,7 +590,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
         yield self.redis.set('pool1:tag1:+54321:session_created', '23.0')
 
         # create message with no tag
-        msg = self.mk_msg('+12345', '+54321', session_event=SESSION_NONE)
+        msg = self.mk_msg('+54321', '+12345', session_event=SESSION_NONE)
 
         with LogCatcher() as lc:
             result_msg = yield mw.handle_outbound(msg, "dummy_connector")
@@ -604,7 +604,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_redis_key_timeout(self):
         mw = yield self.mk_middleware()
-        msg_start = self.mk_msg('+12345', '+54321')
+        msg_start = self.mk_msg('+54321', '+12345')
 
         yield mw.handle_inbound(msg_start, "dummy_connector")
         ttl = yield self.redis.ttl('dummy_transport::+54321:session_created')
@@ -613,7 +613,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_redis_key_custom_timeout(self):
         mw = yield self.mk_middleware(timeout=20)
-        msg_start = self.mk_msg('+12345', '+54321')
+        msg_start = self.mk_msg('+54321', '+12345')
 
         yield mw.handle_inbound(msg_start, "dummy_connector")
         ttl = yield self.redis.ttl('dummy_transport:+54321:session_created')
@@ -622,7 +622,7 @@ class TestSessionLengthMiddleware(VumiTestCase):
     @inlineCallbacks
     def test_custom_message_field_name(self):
         mw = yield self.mk_middleware(field_name='foobar')
-        msg_start = self.mk_msg('+12345', '+54321')
+        msg_start = self.mk_msg('+54321', '+12345')
 
         msg = yield mw.handle_inbound(msg_start, "dummy_connector")
         self.assertEqual(


### PR DESCRIPTION
```
2015-03-09 08:06:29+0000 Unhandled error in Deferred:
2015-03-09 08:06:29+0000 Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 206, in _handle
            message = yield handler(message, connector_name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 115, in handle_consume_outbound
            return self.handle_outbound(message, connector_name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/session_length.py", line 181, in handle_outbound
            return self._process_message(message, self.DIRECTION_OUTBOUND)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1237, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
            result = g.send(result)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/session_length.py", line 166, in _process_message
            redis_key = self._key(message, direction)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/session_length.py", line 110, in _key
            'session_created'))
        exceptions.TypeError: sequence item 1: expected string or Unicode, NoneType found
```