### PR TITLE
Provider middleware fails when to_addr is None.

### DIFF
--- a/vumi/middleware/provider_setter.py
+++ b/vumi/middleware/provider_setter.py
@@ -2,8 +2,16 @@
 
 from confmodel.fields import ConfigDict, ConfigText
 
+from vumi import log
+from vumi.errors import VumiError
 from vumi.middleware.base import TransportMiddleware, BaseMiddlewareConfig
 from vumi.utils import normalize_msisdn
+
+
+class ProviderSettingMiddlewareError(VumiError):
+    """
+    Raised when provider setting middleware encounters an error.
+    """
 
 
 class StaticProviderSetterMiddlewareConfig(BaseMiddlewareConfig):
@@ -117,6 +125,11 @@ class AddressPrefixProviderSettingMiddleware(TransportMiddleware):
         return addr
 
     def get_provider(self, addr):
+        if addr is None:
+            log.error(ProviderSettingMiddlewareError(
+                "Address for determining message provider cannot be None,"
+                " skipping message"))
+            return None
         addr = self.normalize_addr(addr)
         for prefix, provider in self.provider_prefixes:
             if addr.startswith(prefix):

--- a/vumi/middleware/provider_setter.py
+++ b/vumi/middleware/provider_setter.py
@@ -117,9 +117,9 @@ class AddressPrefixProviderSettingMiddleware(TransportMiddleware):
         return addr
 
     def get_provider(self, addr):
-        from_addr = self.normalize_addr(addr)
+        addr = self.normalize_addr(addr)
         for prefix, provider in self.provider_prefixes:
-            if from_addr.startswith(prefix):
+            if addr.startswith(prefix):
                 return provider
         return None
 

--- a/vumi/middleware/provider_setter.py
+++ b/vumi/middleware/provider_setter.py
@@ -1,6 +1,5 @@
 # -*- test-case-name: vumi.middleware.tests.test_provider_setter -*-
 
-from confmodel import Config
 from confmodel.fields import ConfigDict, ConfigText
 
 from vumi.middleware.base import TransportMiddleware, BaseMiddlewareConfig


### PR DESCRIPTION
```
2015-03-09 08:49:52+0000 Unhandled Error
        Traceback (most recent call last):
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/connectors.py", line 65, in handler
            return self._consume_message(mtype, msg)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/connectors.py", line 89, in _consume_message
            d = self._middlewares.apply_consume(mtype, msg, self.name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 216, in apply_consume
            self.consume_middlewares, handler_name, message, connector_name)
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1237, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/var/praekelt/vumi-go/ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
            result = g.send(result)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 206, in _handle
            message = yield handler(message, connector_name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/base.py", line 115, in handle_consume_outbound
            return self.handle_outbound(message, connector_name)
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/provider_setter.py", line 134, in handle_outbound
            message["provider"] = self.get_provider(message["to_addr"])
          File "/var/praekelt/vumi-go/ve/src/vumi/vumi/middleware/provider_setter.py", line 123, in get_provider
            if from_addr.startswith(prefix):
        exceptions.AttributeError: 'NoneType' object has no attribute 'startswith'
```