### PR TITLE
It's easy to fetch all search results accidentally with real_search.

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -474,6 +474,19 @@ class Model(object):
         """
         Performs a real riak search, does no inspection on the given query.
 
+        :param Manager manager:
+            The model manager to use for the query.
+        :param str query:
+            The query to perform.
+        :param int rows:
+            The maximum number of search results to return. The default
+            of ``None`` indicates a backend specific number of rows
+            (usually 1000).
+        :param int start:
+            Numer of the first search result to return. The default of
+            ``None`` is equivalent to ``0`` and starts with the first
+            search result.
+
         :returns: list of keys.
         """
         return manager.real_search(cls, query, rows=rows, start=start)

--- a/vumi/persist/riak_manager.py
+++ b/vumi/persist/riak_manager.py
@@ -293,16 +293,10 @@ class RiakManager(Manager):
 
     def real_search(self, modelcls, query, rows=None, start=None):
         rows = 1000 if rows is None else rows
+        start = 0 if start is None else start
         bucket_name = self.bucket_name(modelcls)
         bucket = self.client.bucket(bucket_name)
-        if start is not None:
-            return self._search_iteration(bucket, query, rows, start)
-        keys = []
-        new_keys = self._search_iteration(bucket, query, rows, 0)
-        while new_keys:
-            keys.extend(new_keys)
-            new_keys = self._search_iteration(bucket, query, rows, len(keys))
-        return keys
+        return self._search_iteration(bucket, query, rows, start)
 
     def riak_enable_search(self, modelcls):
         bucket_name = self.bucket_name(modelcls)

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -429,7 +429,18 @@ class ModelTestMixin(object):
         yield simple_model("yy000001", a=98, b=u'def').save()
         yield simple_model("yy000002", a=98, b=u'ghi').save()
 
-        search = lambda q: simple_model.real_search(q, rows=11)
+        @inlineCallbacks
+        def search(q):
+            results = []
+            while True:
+                new_results = yield simple_model.real_search(
+                    q, rows=11, start=len(results))
+                self.assertTrue(len(new_results) <= 11)
+                results.extend(new_results)
+                if len(new_results) < 11:
+                    break
+            returnValue(results)
+
         yield self.assert_search_results(keys, search, 'a:99')
 
     @Manager.calls_manager

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -324,21 +324,12 @@ class TxRiakManager(Manager):
         d.addCallback(lambda r: [doc["id"] for doc in r["docs"]])
         return d
 
-    @inlineCallbacks
     def real_search(self, modelcls, query, rows=None, start=None):
         rows = 1000 if rows is None else rows
+        start = 0 if start is None else start
         bucket_name = self.bucket_name(modelcls)
         bucket = self.client.bucket(bucket_name)
-        if start is not None:
-            keys = yield self._search_iteration(bucket, query, rows, start)
-            returnValue(keys)
-        keys = []
-        new_keys = yield self._search_iteration(bucket, query, rows, 0)
-        while new_keys:
-            keys.extend(new_keys)
-            new_keys = yield self._search_iteration(
-                bucket, query, rows, len(keys))
-        returnValue(keys)
+        return self._search_iteration(bucket, query, rows, start)
 
     def riak_enable_search(self, modelcls):
         bucket_name = self.bucket_name(modelcls)


### PR DESCRIPTION
Currently passing ``start=None`` to ``real_search`` causes it to ignore ``rows`` and just return all search results (which will often time out).