### PR TITLE
Allow setting session_event when sending non-reply messages.

### DIFF
--- a/vumi/message.py
+++ b/vumi/message.py
@@ -382,11 +382,11 @@ class TransportUserMessage(TransportMessage):
         kw.setdefault('from_addr', None)
         kw.setdefault('transport_name', None)
         kw.setdefault('transport_type', None)
+        kw.setdefault('session_event', cls.SESSION_NONE)
         out_msg = cls(
             to_addr=to_addr,
             in_reply_to=None,
             content=content,
-            session_event=cls.SESSION_NONE,
             **kw)
         return out_msg
 

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -398,6 +398,18 @@ class TransportUserMessageTest(TransportMessageTestMixin, VumiTestCase):
         self.assertEqual(msg['transport_metadata'], {})
         self.assertEqual(msg['helper_metadata'], {})
 
+    def test_transport_user_message_send_with_session_event(self):
+        msg = TransportUserMessage.send(
+            '123', 'Hi!', session_event=TransportUserMessage.SESSION_NEW)
+        self.assertEqual(msg['to_addr'], '123')
+        self.assertEqual(msg['from_addr'], None)
+        self.assertEqual(msg['session_event'], msg.SESSION_NEW)
+        self.assertEqual(msg['in_reply_to'], None)
+        self.assertEqual(msg['transport_name'], None)
+        self.assertEqual(msg['transport_type'], None)
+        self.assertEqual(msg['transport_metadata'], {})
+        self.assertEqual(msg['helper_metadata'], {})
+
 
 class TransportEventTest(TransportMessageTestMixin, VumiTestCase):
     def make_message(self, **extra_fields):


### PR DESCRIPTION
Currently the session_event is hard coded to SESSION_NONE, which makes sense in many cases. However, MT session transports require the initial send to have SESSION_NEW.