### PR TITLE
Add deprecation warnings to sandbox classes

### DIFF
--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -11,6 +11,7 @@ import logging
 import operator
 from uuid import uuid4
 from StringIO import StringIO
+import warnings
 
 from treq.client import HTTPClient
 
@@ -35,6 +36,13 @@ from vumi.persist.txredis_manager import TxRedisManager
 from vumi.utils import load_class_by_string, HttpDataLimitError, to_kwargs
 from vumi import log
 from vumi.application.sandbox_rlimiter import SandboxRlimiter
+
+
+warnings.warn(
+    "Use of vumi.application.sandbox is deprecated, the vumi sandbox worker "
+    "and its components have moved to the vxsandbox package:"
+    "pypi.python.org/pypi/vxsandbox",
+    category=DeprecationWarning)
 
 
 class MultiDeferred(object):

--- a/vumi/application/tests/test_sandbox.py
+++ b/vumi/application/tests/test_sandbox.py
@@ -9,6 +9,7 @@ import pkg_resources
 import logging
 from collections import defaultdict
 from datetime import datetime
+import warnings
 
 from OpenSSL.SSL import (
     VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_NONE,
@@ -28,6 +29,13 @@ from vumi.application.tests.helpers import (
     ApplicationHelper, find_nodejs_or_skip_test)
 from vumi.tests.utils import LogCatcher
 from vumi.tests.helpers import VumiTestCase, PersistenceHelper
+
+
+warnings.warn(
+    "Use of vumi.application.tests.test_sandbox is deprecated, the vumi "
+    "sandbox worker and its components have moved to the vxsandbox package:"
+    "pypi.python.org/pypi/vxsandbox",
+    category=DeprecationWarning)
 
 
 class MockResource(SandboxResource):


### PR DESCRIPTION
Now that we've moved the sandbox code to [vumi-sandbox](https://github.com/praekelt/vumi-sandbox), we need to add deprecation warnings to the code still living in this repo.