### PR TITLE
Reverse timestamp batch indexes for message store

### DIFF
--- a/vumi/components/message_store.py
+++ b/vumi/components/message_store.py
@@ -3,6 +3,7 @@
 
 """Message store."""
 
+from calendar import timegm
 from collections import defaultdict
 from datetime import datetime
 from uuid import uuid4
@@ -21,6 +22,29 @@ from vumi import log
 from vumi.components.message_store_cache import MessageStoreCache
 from vumi.components.message_store_migrators import (
     EventMigrator, InboundMessageMigrator, OutboundMessageMigrator)
+
+
+def to_reverse_timestamp(vumi_timestamp):
+    """
+    Turn a vumi_date-formatted string into a string that sorts in reverse order
+    and can be turned back into a timestamp later.
+
+    This is done by converting to a unix timestamp and subtracting it from
+    0xffffffffff (2**40 - 1) to get a number well outside the range
+    representable by the datetime module. The result is returned as a
+    hexadecimal string.
+    """
+    timestamp = timegm(parse_vumi_date(vumi_timestamp).timetuple())
+    return "%X" % (0xffffffffff - timestamp)
+
+
+def from_reverse_timestamp(reverse_timestamp):
+    """
+    Turn a reverse timestamp string (from `to_reverse_timestamp()`) into a
+    vumi_date-formatted string.
+    """
+    timestamp = 0xffffffffff - int(reverse_timestamp, 16)
+    return format_vumi_date(datetime.utcfromtimestamp(timestamp))
 
 
 class Batch(Model):

--- a/vumi/components/message_store.py
+++ b/vumi/components/message_store.py
@@ -1100,15 +1100,5 @@ def key_with_ts_and_value_formatter(batch_id, result):
 
 
 def key_with_rts_and_value_formatter(batch_id, result):
-    value, key = result
-    prefix = batch_id + "$"
-    if not value.startswith(prefix):
-        raise ValueError(
-            "Index value %r does not begin with expected prefix %r." % (
-                value, prefix))
-    suffix = value[len(prefix):]
-    timestamp, delimiter, address = suffix.partition("$")
-    if delimiter != "$":
-        raise ValueError(
-            "Index value %r does not match expected format." % (value,))
-    return (key, from_reverse_timestamp(timestamp), address)
+    key, reverse_ts, value = key_with_ts_and_value_formatter(batch_id, result)
+    return (key, from_reverse_timestamp(reverse_ts), value)

--- a/vumi/components/message_store_migrators.py
+++ b/vumi/components/message_store_migrators.py
@@ -75,9 +75,30 @@ class OutboundMessageMigrator(MessageMigratorBase):
 
     def reverse_from_3(self, mdata):
         # The only difference between v2 and v3 is an index that's computed at
-        # save time, to the reverse migration is identical to the forward
+        # save time, so the reverse migration is identical to the forward
         # migration except for the version we set.
         mdata.set_value('$VERSION', 2)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches')
+
+        return mdata
+
+    def migrate_from_3(self, mdata):
+        # We only copy existing fields and indexes over. The new fields and
+        # indexes are computed at save time.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches')
+
+        return mdata
+
+    def reverse_from_4(self, mdata):
+        # The only difference between v3 and v4 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 3)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
         mdata.copy_indexes('batches')
@@ -116,9 +137,30 @@ class InboundMessageMigrator(MessageMigratorBase):
 
     def reverse_from_3(self, mdata):
         # The only difference between v2 and v3 is an index that's computed at
-        # save time, to the reverse migration is identical to the forward
+        # save time, so the reverse migration is identical to the forward
         # migration except for the version we set.
         mdata.set_value('$VERSION', 2)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches')
+
+        return mdata
+
+    def migrate_from_3(self, mdata):
+        # We only copy existing fields and indexes over. The new fields and
+        # indexes are computed at save time.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches')
+
+        return mdata
+
+    def reverse_from_4(self, mdata):
+        # The only difference between v3 and v4 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 3)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
         mdata.copy_indexes('batches')

--- a/vumi/components/tests/test_message_store.py
+++ b/vumi/components/tests/test_message_store.py
@@ -11,6 +11,50 @@ from vumi.tests.helpers import (
     VumiTestCase, MessageHelper, PersistenceHelper, import_skip)
 
 
+class TestReverseTimestampUtils(VumiTestCase):
+
+    def setUp(self):
+        try:
+            from vumi.components.message_store import (
+                to_reverse_timestamp, from_reverse_timestamp)
+        except ImportError, e:
+            import_skip(e, 'riak')
+        self.to_reverse_timestamp = to_reverse_timestamp
+        self.from_reverse_timestamp = from_reverse_timestamp
+
+    def test_to_reverse_timestamp(self):
+        """
+        to_reverse_timestamp() turns a vumi_date-formatted string into a
+        reverse timestamp.
+        """
+        self.assertEqual(
+            "FFAAE41F25", self.to_reverse_timestamp("2015-04-01 12:13:14"))
+        self.assertEqual(
+            "FFAAE41F25",
+            self.to_reverse_timestamp("2015-04-01 12:13:14.000000"))
+        self.assertEqual(
+            "FFAAE41F25",
+            self.to_reverse_timestamp("2015-04-01 12:13:14.999999"))
+        self.assertEqual(
+            "FFAAE41F24", self.to_reverse_timestamp("2015-04-01 12:13:15"))
+        self.assertEqual(
+            "F0F9025FA5", self.to_reverse_timestamp("4015-04-01 12:13:14"))
+
+    def test_from_reverse_timestamp(self):
+        """
+        from_reverse_timestamp() is the inverse of to_reverse_timestamp().
+        """
+        self.assertEqual(
+            "2015-04-01 12:13:14.000000",
+            self.from_reverse_timestamp("FFAAE41F25"))
+        self.assertEqual(
+            "2015-04-01 12:13:13.000000",
+            self.from_reverse_timestamp("FFAAE41F26"))
+        self.assertEqual(
+            "4015-04-01 12:13:14.000000",
+            self.from_reverse_timestamp("F0F9025FA5"))
+
+
 class TestMessageStoreBase(VumiTestCase):
 
     @inlineCallbacks

--- a/vumi/components/tests/test_message_store.py
+++ b/vumi/components/tests/test_message_store.py
@@ -946,7 +946,6 @@ class TestMessageStore(TestMessageStoreBase):
         all_keys = [(key, timestamp, addr)
                     for (timestamp, addr, key) in sorted_keys]
 
-        print all_keys
         page = yield self.store.batch_inbound_keys_with_addresses_reverse(
             batch_id, max_results=6, start=all_keys[-2][1])
         self.assertEqual(list(page), all_keys[:-1])
@@ -1013,7 +1012,6 @@ class TestMessageStore(TestMessageStoreBase):
         all_keys = [(key, timestamp, addr)
                     for (timestamp, addr, key) in sorted_keys]
 
-        print all_keys
         page = yield self.store.batch_outbound_keys_with_addresses_reverse(
             batch_id, max_results=6, start=all_keys[-2][1])
         self.assertEqual(list(page), all_keys[:-1])

--- a/vumi/components/tests/test_message_store_migrators.py
+++ b/vumi/components/tests/test_message_store_migrators.py
@@ -2,6 +2,7 @@
 
 from twisted.internet.defer import inlineCallbacks
 
+from vumi.message import format_vumi_date
 from vumi.tests.helpers import (
     VumiTestCase, MessageHelper, PersistenceHelper, import_skip)
 
@@ -9,10 +10,11 @@ try:
     from vumi.components.tests.message_store_old_models import (
         OutboundMessageVNone, InboundMessageVNone, EventVNone, BatchVNone,
         OutboundMessageV1, InboundMessageV1, OutboundMessageV2,
-        InboundMessageV2)
+        InboundMessageV2, OutboundMessageV3, InboundMessageV3)
     from vumi.components.message_store import (
-        OutboundMessage as OutboundMessageV3,
-        InboundMessage as InboundMessageV3,
+        to_reverse_timestamp,
+        OutboundMessage as OutboundMessageV4,
+        InboundMessage as InboundMessageV4,
         Event as EventV1)
     riak_import_error = None
 except ImportError, e:
@@ -35,6 +37,16 @@ def bwa_out_value(batch_id, msg):
     return "%s$%s$%s" % (batch_id, msg['timestamp'], msg['to_addr'])
 
 
+def bwar_in_value(batch_id, msg):
+    reverse_ts = to_reverse_timestamp(format_vumi_date(msg['timestamp']))
+    return "%s$%s$%s" % (batch_id, reverse_ts, msg['from_addr'])
+
+
+def bwar_out_value(batch_id, msg):
+    reverse_ts = to_reverse_timestamp(format_vumi_date(msg['timestamp']))
+    return "%s$%s$%s" % (batch_id, reverse_ts, msg['to_addr'])
+
+
 def batch_index(value):
     return ("batches_bin", value)
 
@@ -45,6 +57,10 @@ def bwt_index(value):
 
 def bwa_index(value):
     return ("batches_with_addresses_bin", value)
+
+
+def bwar_index(value):
+    return ("batches_with_addresses_reverse_bin", value)
 
 
 class TestMigratorBase(VumiTestCase):
@@ -162,6 +178,7 @@ class TestOutboundMessageMigrator(TestMigratorBase):
         self.outbound_v1 = self.manager.proxy(OutboundMessageV1)
         self.outbound_v2 = self.manager.proxy(OutboundMessageV2)
         self.outbound_v3 = self.manager.proxy(OutboundMessageV3)
+        self.outbound_v4 = self.manager.proxy(OutboundMessageV4)
         self.batch_vnone = self.manager.proxy(BatchVNone)
 
     @inlineCallbacks
@@ -362,6 +379,136 @@ class TestOutboundMessageMigrator(TestMigratorBase):
         self.assertEqual(old_record.msg, msg)
         self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
 
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_no_batches(self):
+        """
+        A v3 model with no batches has no extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_record = self.outbound_v3(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.outbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_one_batch(self):
+        """
+        A v3 model with one batch gets one extra index when migrated to v4.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.outbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_timestamps),
+            set([bwt_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_out_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_out_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_two_batches(self):
+        """
+        A v3 model with two batches gets two extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.outbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v4_to_v3(self):
+        """
+        A v4 model can be stored in a v3-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.outbound_v4._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 3
+
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.outbound_v4(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.outbound_v3.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
 
 class TestInboundMessageMigrator(TestMigratorBase):
 
@@ -372,6 +519,7 @@ class TestInboundMessageMigrator(TestMigratorBase):
         self.inbound_v1 = self.manager.proxy(InboundMessageV1)
         self.inbound_v2 = self.manager.proxy(InboundMessageV2)
         self.inbound_v3 = self.manager.proxy(InboundMessageV3)
+        self.inbound_v4 = self.manager.proxy(InboundMessageV4)
         self.batch_vnone = self.manager.proxy(BatchVNone)
 
     @inlineCallbacks
@@ -569,5 +717,135 @@ class TestInboundMessageMigrator(TestMigratorBase):
         yield new_record.save()
 
         old_record = yield self.inbound_v2.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_no_batches(self):
+        """
+        A v3 model with no batches gets no extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_record = self.inbound_v3(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.inbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_one_batch(self):
+        """
+        A v3 model with one batche gets one extra index when migrated to v4.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.inbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_timestamps),
+            set([bwt_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_in_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_in_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_two_batches(self):
+        """
+        A v3 model with two batches gets two extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.inbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v4_to_v3(self):
+        """
+        A v4 model can be stored in a v3-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.inbound_v4._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 3
+
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.inbound_v3(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.inbound_v3.load(new_record.key)
         self.assertEqual(old_record.msg, msg)
         self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])

--- a/vumi/components/tests/test_message_store_migrators.py
+++ b/vumi/components/tests/test_message_store_migrators.py
@@ -841,7 +841,7 @@ class TestInboundMessageMigrator(TestMigratorBase):
         msg = self.msg_helper.make_inbound("inbound")
         batch_1 = self.batch_vnone(key=u"batch-1")
         batch_2 = self.batch_vnone(key=u"batch-2")
-        new_record = self.inbound_v3(msg["message_id"], msg=msg)
+        new_record = self.inbound_v4(msg["message_id"], msg=msg)
         new_record.batches.add_key(batch_1.key)
         new_record.batches.add_key(batch_2.key)
         yield new_record.save()


### PR DESCRIPTION
We often want message store index results in reverse time order, which currently means walking the entire index to get the results we need.

(I was originally planning to add similar indexes to stored events as well, but that changes the message store API and is therefore best left for a new PR.)