### PR TITLE
Remove unnecessary message store indexes

### DIFF
--- a/vumi/components/message_store.py
+++ b/vumi/components/message_store.py
@@ -90,7 +90,7 @@ class CurrentTag(Model):
 
 
 class OutboundMessage(Model):
-    VERSION = 4
+    VERSION = 5
     MIGRATOR = OutboundMessageMigrator
 
     # key is message_id
@@ -98,13 +98,11 @@ class OutboundMessage(Model):
     batches = ManyToMany(Batch)
 
     # Extra fields for compound indexes
-    batches_with_timestamps = ListOf(Unicode(), index=True)
     batches_with_addresses = ListOf(Unicode(), index=True)
     batches_with_addresses_reverse = ListOf(Unicode(), index=True)
 
     def save(self):
         # We override this method to set our index fields before saving.
-        self.batches_with_timestamps = []
         self.batches_with_addresses = []
         self.batches_with_addresses_reverse = []
         timestamp = self.msg['timestamp']
@@ -112,8 +110,6 @@ class OutboundMessage(Model):
             timestamp = format_vumi_date(timestamp)
         reverse_ts = to_reverse_timestamp(timestamp)
         for batch_id in self.batches.keys():
-            self.batches_with_timestamps.append(
-                u"%s$%s" % (batch_id, timestamp))
             self.batches_with_addresses.append(
                 u"%s$%s$%s" % (batch_id, timestamp, self.msg['to_addr']))
             self.batches_with_addresses_reverse.append(
@@ -153,7 +149,7 @@ class Event(Model):
 
 
 class InboundMessage(Model):
-    VERSION = 4
+    VERSION = 5
     MIGRATOR = InboundMessageMigrator
 
     # key is message_id
@@ -161,13 +157,11 @@ class InboundMessage(Model):
     batches = ManyToMany(Batch)
 
     # Extra fields for compound indexes
-    batches_with_timestamps = ListOf(Unicode(), index=True)
     batches_with_addresses = ListOf(Unicode(), index=True)
     batches_with_addresses_reverse = ListOf(Unicode(), index=True)
 
     def save(self):
         # We override this method to set our index fields before saving.
-        self.batches_with_timestamps = []
         self.batches_with_addresses = []
         self.batches_with_addresses_reverse = []
         timestamp = self.msg['timestamp']
@@ -175,8 +169,6 @@ class InboundMessage(Model):
             timestamp = format_vumi_date(timestamp)
         reverse_ts = to_reverse_timestamp(timestamp)
         for batch_id in self.batches.keys():
-            self.batches_with_timestamps.append(
-                u"%s$%s" % (batch_id, timestamp))
             self.batches_with_addresses.append(
                 u"%s$%s$%s" % (batch_id, timestamp, self.msg['from_addr']))
             self.batches_with_addresses_reverse.append(

--- a/vumi/components/message_store_migrators.py
+++ b/vumi/components/message_store_migrators.py
@@ -139,6 +139,31 @@ class OutboundMessageMigrator(MessageMigratorBase):
 
         return mdata
 
+    def migrate_from_4(self, mdata):
+        # We copy existing fields and indexes over except for the indexes we're
+        # removing.
+        mdata.set_value('$VERSION', 5)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
+
+        return mdata
+
+    def reverse_from_5(self, mdata):
+        # The only difference between v4 and v5 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
+
+        return mdata
+
 
 class InboundMessageMigrator(MessageMigratorBase):
     def migrate_from_unversioned(self, mdata):
@@ -204,5 +229,30 @@ class InboundMessageMigrator(MessageMigratorBase):
         mdata.copy_indexes('batches_bin')
         mdata.copy_indexes('batches_with_timestamps_bin')
         mdata.copy_indexes('batches_with_addresses_bin')
+
+        return mdata
+
+    def migrate_from_4(self, mdata):
+        # We copy existing fields and indexes over except for the indexes we're
+        # removing.
+        mdata.set_value('$VERSION', 5)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
+
+        return mdata
+
+    def reverse_from_5(self, mdata):
+        # The only difference between v4 and v5 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
 
         return mdata

--- a/vumi/components/tests/message_store_old_models.py
+++ b/vumi/components/tests/message_store_old_models.py
@@ -1,7 +1,10 @@
 """Previous versions of message store models."""
 
+from calendar import timegm
+from datetime import datetime
 
-from vumi.message import TransportUserMessage, TransportEvent, format_vumi_date
+from vumi.message import (
+    TransportUserMessage, TransportEvent, format_vumi_date, parse_vumi_date)
 from vumi.persist.model import Model
 from vumi.persist.fields import (
     VumiMessage, ForeignKey, ListOf, Dynamic, Tag, Unicode, ManyToMany)
@@ -187,3 +190,94 @@ class EventV1(Model):
         self.message_with_status = u"%s$%s$%s" % (
             self.message.key, timestamp, status)
         return super(EventV1, self).save()
+
+
+def to_reverse_timestamp(vumi_timestamp):
+    """
+    Turn a vumi_date-formatted string into a string that sorts in reverse order
+    and can be turned back into a timestamp later.
+
+    This is done by converting to a unix timestamp and subtracting it from
+    0xffffffffff (2**40 - 1) to get a number well outside the range
+    representable by the datetime module. The result is returned as a
+    hexadecimal string.
+    """
+    timestamp = timegm(parse_vumi_date(vumi_timestamp).timetuple())
+    return "%X" % (0xffffffffff - timestamp)
+
+
+def from_reverse_timestamp(reverse_timestamp):
+    """
+    Turn a reverse timestamp string (from `to_reverse_timestamp()`) into a
+    vumi_date-formatted string.
+    """
+    timestamp = 0xffffffffff - int(reverse_timestamp, 16)
+    return format_vumi_date(datetime.utcfromtimestamp(timestamp))
+
+
+class OutboundMessageV4(Model):
+    bucket = 'outboundmessage'
+
+    VERSION = 4
+    MIGRATOR = OutboundMessageMigrator
+
+    # key is message_id
+    msg = VumiMessage(TransportUserMessage)
+    batches = ManyToMany(BatchVNone)
+
+    # Extra fields for compound indexes
+    batches_with_timestamps = ListOf(Unicode(), index=True)
+    batches_with_addresses = ListOf(Unicode(), index=True)
+    batches_with_addresses_reverse = ListOf(Unicode(), index=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        self.batches_with_timestamps = []
+        self.batches_with_addresses = []
+        self.batches_with_addresses_reverse = []
+        timestamp = self.msg['timestamp']
+        if not isinstance(timestamp, basestring):
+            timestamp = format_vumi_date(timestamp)
+        reverse_ts = to_reverse_timestamp(timestamp)
+        for batch_id in self.batches.keys():
+            self.batches_with_timestamps.append(
+                u"%s$%s" % (batch_id, timestamp))
+            self.batches_with_addresses.append(
+                u"%s$%s$%s" % (batch_id, timestamp, self.msg['to_addr']))
+            self.batches_with_addresses_reverse.append(
+                u"%s$%s$%s" % (batch_id, reverse_ts, self.msg['to_addr']))
+        return super(OutboundMessageV4, self).save()
+
+
+class InboundMessageV4(Model):
+    bucket = 'inboundmessage'
+
+    VERSION = 4
+    MIGRATOR = InboundMessageMigrator
+
+    # key is message_id
+    msg = VumiMessage(TransportUserMessage)
+    batches = ManyToMany(BatchVNone)
+
+    # Extra fields for compound indexes
+    batches_with_timestamps = ListOf(Unicode(), index=True)
+    batches_with_addresses = ListOf(Unicode(), index=True)
+    batches_with_addresses_reverse = ListOf(Unicode(), index=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        self.batches_with_timestamps = []
+        self.batches_with_addresses = []
+        self.batches_with_addresses_reverse = []
+        timestamp = self.msg['timestamp']
+        if not isinstance(timestamp, basestring):
+            timestamp = format_vumi_date(timestamp)
+        reverse_ts = to_reverse_timestamp(timestamp)
+        for batch_id in self.batches.keys():
+            self.batches_with_timestamps.append(
+                u"%s$%s" % (batch_id, timestamp))
+            self.batches_with_addresses.append(
+                u"%s$%s$%s" % (batch_id, timestamp, self.msg['from_addr']))
+            self.batches_with_addresses_reverse.append(
+                u"%s$%s$%s" % (batch_id, reverse_ts, self.msg['from_addr']))
+        return super(InboundMessageV4, self).save()

--- a/vumi/components/tests/test_message_store.py
+++ b/vumi/components/tests/test_message_store.py
@@ -236,10 +236,6 @@ class TestMessageStore(TestMessageStoreBase):
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', batch_id_1),
             ('batches_bin', batch_id_2),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % (batch_id_1, timestamp)),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % (batch_id_2, timestamp)),
             ('batches_with_addresses_bin',
              "%s$%s$%s" % (batch_id_1, timestamp, msg['to_addr'])),
             ('batches_with_addresses_bin',
@@ -533,10 +529,6 @@ class TestMessageStore(TestMessageStoreBase):
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', batch_id_1),
             ('batches_bin', batch_id_2),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % (batch_id_1, timestamp)),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % (batch_id_2, timestamp)),
             ('batches_with_addresses_bin',
              "%s$%s$%s" % (batch_id_1, timestamp, msg['from_addr'])),
             ('batches_with_addresses_bin',

--- a/vumi/components/tests/test_message_store_migrators.py
+++ b/vumi/components/tests/test_message_store_migrators.py
@@ -10,11 +10,12 @@ try:
     from vumi.components.tests.message_store_old_models import (
         OutboundMessageVNone, InboundMessageVNone, EventVNone, BatchVNone,
         OutboundMessageV1, InboundMessageV1, OutboundMessageV2,
-        InboundMessageV2, OutboundMessageV3, InboundMessageV3, EventV1)
+        InboundMessageV2, OutboundMessageV3, InboundMessageV3, EventV1,
+        OutboundMessageV4, InboundMessageV4)
     from vumi.components.message_store import (
         to_reverse_timestamp,
-        OutboundMessage as OutboundMessageV4,
-        InboundMessage as InboundMessageV4,
+        OutboundMessage as OutboundMessageV5,
+        InboundMessage as InboundMessageV5,
         Event as EventV2)
     riak_import_error = None
 except ImportError, e:
@@ -270,6 +271,7 @@ class TestOutboundMessageMigrator(TestMigratorBase):
         self.outbound_v2 = self.manager.proxy(OutboundMessageV2)
         self.outbound_v3 = self.manager.proxy(OutboundMessageV3)
         self.outbound_v4 = self.manager.proxy(OutboundMessageV4)
+        self.outbound_v5 = self.manager.proxy(OutboundMessageV5)
         self.batch_vnone = self.manager.proxy(BatchVNone)
 
     @inlineCallbacks
@@ -600,6 +602,128 @@ class TestOutboundMessageMigrator(TestMigratorBase):
         self.assertEqual(old_record.msg, msg)
         self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
 
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_no_batches(self):
+        """
+        A v4 model with no batches has no fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_record = self.outbound_v4(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.outbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_one_batch(self):
+        """
+        A v4 model with one batch gets one fewer index when migrated to v5.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.outbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_out_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_out_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_two_batches(self):
+        """
+        A v4 model with two batches gets two fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.outbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v5_to_v4(self):
+        """
+        A v5 model can be stored in a v4-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.outbound_v5._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 4
+
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.outbound_v5(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.outbound_v4.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
 
 class TestInboundMessageMigrator(TestMigratorBase):
 
@@ -611,6 +735,7 @@ class TestInboundMessageMigrator(TestMigratorBase):
         self.inbound_v2 = self.manager.proxy(InboundMessageV2)
         self.inbound_v3 = self.manager.proxy(InboundMessageV3)
         self.inbound_v4 = self.manager.proxy(InboundMessageV4)
+        self.inbound_v5 = self.manager.proxy(InboundMessageV5)
         self.batch_vnone = self.manager.proxy(BatchVNone)
 
     @inlineCallbacks
@@ -938,5 +1063,127 @@ class TestInboundMessageMigrator(TestMigratorBase):
         yield new_record.save()
 
         old_record = yield self.inbound_v3.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_no_batches(self):
+        """
+        A v4 model with no batches gets no fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_record = self.inbound_v4(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.inbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_one_batch(self):
+        """
+        A v4 model with one batch gets one fewer index when migrated to v5.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.inbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_in_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_in_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_two_batches(self):
+        """
+        A v4 model with two batches gets two fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.inbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v5_to_v4(self):
+        """
+        A v5 model can be stored in a v4-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.inbound_v5._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 4
+
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.inbound_v5(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.inbound_v4.load(new_record.key)
         self.assertEqual(old_record.msg, msg)
         self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])


### PR DESCRIPTION
We currently have some unnecessary indexes on our message store objects, which may be contributing to Riak load and are definitely contributing to code complexity.