### PR TITLE
TxRiakManager needs its own threadpool

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -661,6 +661,11 @@ class Manager(object):
         self._bucket_cache = {}
         self.store_versions = store_versions or {}
 
+        self._setup_manager()
+
+    def _setup_manager(self):
+        pass
+
     def proxy(self, modelcls):
         return ModelProxy(self, modelcls)
 

--- a/vumi/persist/tests/test_txriak_manager.py
+++ b/vumi/persist/tests/test_txriak_manager.py
@@ -332,3 +332,13 @@ class TestTxRiakManager(CommonRiakManagerTests, VumiTestCase):
             })
         self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.client.protocol, 'http')
+
+    @Manager.calls_manager
+    def test_cannot_use_closed_manager(self):
+        """
+        We can't use a manager that is already closed.
+        """
+        yield self.manager.close_manager()
+        dummy = self.mkdummy("unknown")
+        yield self.assertFailure(
+            self.manager.load(DummyModel, dummy.key), RuntimeError)

--- a/vumi/persist/tests/test_txriak_manager.py
+++ b/vumi/persist/tests/test_txriak_manager.py
@@ -67,6 +67,7 @@ class CommonRiakManagerTests(object):
     def test_from_config(self):
         manager_cls = self.manager.__class__
         manager = manager_cls.from_config({'bucket_prefix': 'test.'})
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.__class__, manager_cls)
         self.assertEqual(manager.load_bunch_size,
                          manager.DEFAULT_LOAD_BUNCH_SIZE)
@@ -78,6 +79,7 @@ class CommonRiakManagerTests(object):
         manager = manager_cls.from_config({'bucket_prefix': 'test.',
                                            'load_bunch_size': 10,
                                            })
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.load_bunch_size, 10)
 
     def test_from_config_with_mapreduce_timeout(self):
@@ -85,6 +87,7 @@ class CommonRiakManagerTests(object):
         manager = manager_cls.from_config({'bucket_prefix': 'test.',
                                            'mapreduce_timeout': 1000,
                                            })
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.mapreduce_timeout, 1000)
 
     def test_from_config_with_store_versions(self):
@@ -96,6 +99,7 @@ class CommonRiakManagerTests(object):
                 'bar.Bar': None,
             },
         })
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.store_versions, {
             'foo.Foo': 3,
             'bar.Bar': None,
@@ -103,6 +107,7 @@ class CommonRiakManagerTests(object):
 
     def test_sub_manager(self):
         sub_manager = self.manager.sub_manager("foo.")
+        self.add_cleanup(sub_manager.close_manager)
         self.assertEqual(sub_manager.client, self.manager.client)
         self.assertEqual(sub_manager.bucket_prefix, 'test.foo.')
 
@@ -295,6 +300,7 @@ class TestTxRiakManager(CommonRiakManagerTests, VumiTestCase):
         except ImportError, e:
             import_skip(e, 'riak', 'riak')
         self.manager = TxRiakManager.from_config({'bucket_prefix': 'test.'})
+        self.add_cleanup(self.manager.close_manager)
         self.add_cleanup(self.manager.purge_all)
         yield self.manager.purge_all()
 
@@ -307,6 +313,7 @@ class TestTxRiakManager(CommonRiakManagerTests, VumiTestCase):
             'transport_type': 'pbc',
             'bucket_prefix': 'test.',
             })
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.client.protocol, 'pbc')
 
     def test_transport_class_http(self):
@@ -315,6 +322,7 @@ class TestTxRiakManager(CommonRiakManagerTests, VumiTestCase):
             'transport_type': 'http',
             'bucket_prefix': 'test.',
             })
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.client.protocol, 'http')
 
     def test_transport_class_default(self):
@@ -322,4 +330,5 @@ class TestTxRiakManager(CommonRiakManagerTests, VumiTestCase):
         manager = manager_class.from_config({
             'bucket_prefix': 'test.',
             })
+        self.add_cleanup(manager.close_manager)
         self.assertEqual(manager.client.protocol, 'http')

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -5,7 +5,8 @@
 import json
 
 from riak import RiakClient, RiakObject, RiakMapReduce, RiakError
-from twisted.internet.threads import deferToThread
+from twisted.python.threadpool import ThreadPool
+from twisted.internet.threads import deferToThreadPool
 from twisted.internet.defer import (
     inlineCallbacks, returnValue, gatherResults, maybeDeferred, succeed)
 
@@ -34,8 +35,9 @@ class VumiTxIndexPage(object):
     Iterating over this object will return the results for the current page.
     """
 
-    def __init__(self, index_page):
+    def __init__(self, index_page, manager):
         self._index_page = index_page
+        self._manager = manager
 
     def __iter__(self):
         if self._index_page.stream:
@@ -71,15 +73,16 @@ class VumiTxIndexPage(object):
         """
         if not self.has_next_page():
             return succeed(None)
-        d = deferToThread(self._index_page.next_page)
-        d.addCallback(type(self))
+        d = self._manager.deferToThread(self._index_page.next_page)
+        d.addCallback(type(self), self._manager)
         d.addErrback(riakErrorHandler)
         return d
 
 
 class VumiTxRiakBucket(object):
-    def __init__(self, riak_bucket):
+    def __init__(self, riak_bucket, manager):
         self._riak_bucket = riak_bucket
+        self._manager = manager
 
     def get_name(self):
         return self._riak_bucket.name
@@ -95,18 +98,19 @@ class VumiTxRiakBucket(object):
 
     def get_index_page(self, index_name, start_value, end_value=None,
                        return_terms=None, max_results=None, continuation=None):
-        d = deferToThread(
+        d = self._manager.deferToThread(
             self._riak_bucket.get_index, index_name, start_value, end_value,
             return_terms=return_terms, max_results=max_results,
             continuation=continuation)
-        d.addCallback(VumiTxIndexPage)
+        d.addCallback(VumiTxIndexPage, self._manager)
         d.addErrback(riakErrorHandler)
         return d
 
 
 class VumiTxRiakObject(object):
-    def __init__(self, riak_obj):
+    def __init__(self, riak_obj, manager):
         self._riak_obj = riak_obj
+        self._manager = manager
 
     @property
     def key(self):
@@ -155,23 +159,23 @@ class VumiTxRiakObject(object):
         self._riak_obj.usermeta = usermeta
 
     def get_bucket(self):
-        return VumiTxRiakBucket(self._riak_obj.bucket)
+        return VumiTxRiakBucket(self._riak_obj.bucket, self._manager)
 
     # Methods that touch the network.
 
     def store(self):
-        d = deferToThread(self._riak_obj.store)
-        d.addCallback(type(self))
+        d = self._manager.deferToThread(self._riak_obj.store)
+        d.addCallback(type(self), self._manager)
         return d
 
     def reload(self):
-        d = deferToThread(self._riak_obj.reload)
-        d.addCallback(type(self))
+        d = self._manager.deferToThread(self._riak_obj.reload)
+        d.addCallback(type(self), self._manager)
         return d
 
     def delete(self):
-        d = deferToThread(self._riak_obj.delete)
-        d.addCallback(type(self))
+        d = self._manager.deferToThread(self._riak_obj.delete)
+        d.addCallback(type(self), self._manager)
         return d
 
 
@@ -179,6 +183,16 @@ class TxRiakManager(Manager):
     """An async persistence manager for the riak Python package."""
 
     call_decorator = staticmethod(inlineCallbacks)
+
+    def _setup_manager(self):
+        from twisted.internet import reactor
+        self._reactor = reactor
+        self._threadpool = ThreadPool(minthreads=2, maxthreads=2)
+        self._threadpool.start()
+
+    def deferToThread(self, f, *args, **kw):
+        return deferToThreadPool(
+            self._reactor, self._threadpool, f, *args, **kw)
 
     @classmethod
     def from_config(cls, config):
@@ -220,17 +234,18 @@ class TxRiakManager(Manager):
             mapreduce_timeout=mapreduce_timeout, store_versions=store_versions)
 
     def close_manager(self):
-        return deferToThread(self.client.close)
+        return self.deferToThread(self.client.close)
 
     def riak_bucket(self, bucket_name):
         bucket = self.client.bucket(bucket_name)
         if bucket is not None:
-            bucket = VumiTxRiakBucket(bucket)
+            bucket = VumiTxRiakBucket(bucket, self)
         return bucket
 
     def riak_object(self, modelcls, key, result=None):
         bucket = self.bucket_for_modelcls(modelcls)._riak_bucket
-        riak_object = VumiTxRiakObject(RiakObject(self.client, bucket, key))
+        riak_object = VumiTxRiakObject(
+            RiakObject(self.client, bucket, key), self)
         if result:
             metadata = result['metadata']
             indexes = metadata['index']
@@ -295,15 +310,15 @@ class TxRiakManager(Manager):
         return d
 
     def riak_map_reduce(self):
-        mapreduce = RiakMapReduce(self.client)
+        mr = RiakMapReduce(self.client)
         # Hack: We replace the two methods that hit the network with
         #       deferToThread wrappers to prevent accidental sync calls in
         #       other code.
-        run = mapreduce.run
-        stream = mapreduce.stream
-        mapreduce.run = lambda *a, **kw: deferToThread(run, *a, **kw)
-        mapreduce.stream = lambda *a, **kw: deferToThread(stream, *a, **kw)
-        return mapreduce
+        run = mr.run
+        stream = mr.stream
+        mr.run = lambda *a, **kw: self.deferToThread(run, *a, **kw)
+        mr.stream = lambda *a, **kw: self.deferToThread(stream, *a, **kw)
+        return mr
 
     def run_map_reduce(self, mapreduce, mapper_func=None, reducer_func=None):
         def map_results(raw_results):
@@ -320,7 +335,7 @@ class TxRiakManager(Manager):
         return mapreduce_done
 
     def _search_iteration(self, bucket, query, rows, start):
-        d = deferToThread(bucket.search, query, rows=rows, start=start)
+        d = self.deferToThread(bucket.search, query, rows=rows, start=start)
         d.addCallback(lambda r: [doc["id"] for doc in r["docs"]])
         return d
 
@@ -343,12 +358,12 @@ class TxRiakManager(Manager):
     def riak_enable_search(self, modelcls):
         bucket_name = self.bucket_name(modelcls)
         bucket = self.client.bucket(bucket_name)
-        return deferToThread(bucket.enable_search)
+        return self.deferToThread(bucket.enable_search)
 
     def riak_search_enabled(self, modelcls):
         bucket_name = self.bucket_name(modelcls)
         bucket = self.client.bucket(bucket_name)
-        return deferToThread(bucket.search_enabled)
+        return self.deferToThread(bucket.search_enabled)
 
     def should_quote_index_values(self):
         return False
@@ -363,13 +378,14 @@ class TxRiakManager(Manager):
         def purge_bucket(bucket):
             key_deletes = []
             for key in bucket.get_keys():
-                key_deletes.append(deferToThread(delete_obj, bucket, key))
+                key_deletes.append(self.deferToThread(delete_obj, bucket, key))
             d = gatherResults(key_deletes)
-            d.addCallback(lambda _: deferToThread(bucket.clear_properties))
+            d.addCallback(
+                lambda _: self.deferToThread(bucket.clear_properties))
             return d
 
         bucket_deletes = []
-        buckets = yield deferToThread(self.client.get_buckets)
+        buckets = yield self.deferToThread(self.client.get_buckets)
         for bucket in buckets:
             if bucket.name.startswith(self.bucket_prefix):
                 bucket_deletes.append(purge_bucket(bucket))

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -208,7 +208,7 @@ class TxRiakManager(Manager):
         self._threadpool.start()
 
     def deferToThread(self, f, *args, **kw):
-        if not self._threadpool.started:
+        if self._threadpool.joined:
             raise RuntimeError("Can't use a closed TxRiakManager.")
         return deferToThreadPool(
             self._reactor, self._threadpool, f, *args, **kw)
@@ -253,7 +253,7 @@ class TxRiakManager(Manager):
             mapreduce_timeout=mapreduce_timeout, store_versions=store_versions)
 
     def close_manager(self):
-        if not self._threadpool.started:
+        if self._threadpool.joined:
             return succeed(None)
         d = self.deferToThread(self.client.close)
         d.addCallback(lambda _: self._threadpool.stop())
@@ -397,7 +397,7 @@ class TxRiakManager(Manager):
         # we restart the threadpool and close the manager again when we're
         # done.
 
-        was_closed = not self._threadpool.started
+        was_closed = self._threadpool.joined
         if was_closed:
             self._threadpool.start()
 

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -252,7 +252,7 @@ class TxRiakManager(Manager):
 
     def close_manager(self):
         d = self.deferToThread(self.client.close)
-        d.addCallback(lambda _: self._threadpool.stop)
+        d.addCallback(lambda _: self._threadpool.stop())
         return d
 
     def riak_bucket(self, bucket_name):


### PR DESCRIPTION
It currently uses the general reactor threadpool, but we want tighter control over concurrency and we don't want to muck about with the reactor's threadpool in case other things are using it.