### PR TITLE
Better Riak management in script tests

### DIFF
--- a/vumi/scripts/tests/test_model_migrator.py
+++ b/vumi/scripts/tests/test_model_migrator.py
@@ -14,15 +14,24 @@ class SimpleModel(Model):
 
 class StubbedModelMigrator(ModelMigrator):
     def __init__(self, testcase, *args, **kwargs):
+        # So we can patch the manager's load function to simulate failures.
+        self._manager_load_func = kwargs.pop("manager_load_func", None)
         self.testcase = testcase
         self.output = []
+        self.recorded_loads = []
+        self.recorded_stores = []
         super(StubbedModelMigrator, self).__init__(*args, **kwargs)
 
     def emit(self, s):
         self.output.append(s)
 
     def get_riak_manager(self, riak_config):
-        return self.testcase.get_sub_riak(riak_config)
+        manager = self.testcase.get_riak_manager(riak_config)
+        if self._manager_load_func is not None:
+            self.testcase.patch(manager, "load", self._manager_load_func)
+        self.testcase.persistence_helper.record_load_and_store(
+            manager, self.recorded_loads, self.recorded_stores)
+        return manager
 
 
 class TestModelMigrator(VumiTestCase):
@@ -30,48 +39,37 @@ class TestModelMigrator(VumiTestCase):
     def setUp(self):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True, is_sync=True))
-        self.riak_manager = self.persistence_helper.get_riak_manager()
+        self.expected_bucket_prefix = "bucket"
+        self.riak_manager = self.persistence_helper.get_riak_manager({
+            "bucket_prefix": self.expected_bucket_prefix,
+        })
         self.model = self.riak_manager.proxy(SimpleModel)
         self.model_cls_path = ".".join([
             SimpleModel.__module__, SimpleModel.__name__])
-        self.expected_bucket_prefix = "bucket"
         self.default_args = [
             "-m", self.model_cls_path,
             "-b", self.expected_bucket_prefix,
         ]
 
-    def make_migrator(self, args=None):
+    def make_migrator(self, args=None, manager_load_func=None):
         if args is None:
             args = self.default_args
         options = Options()
         options.parseOptions(args)
-        return StubbedModelMigrator(self, options)
+        return StubbedModelMigrator(
+            self, options, manager_load_func=manager_load_func)
 
-    def get_sub_riak(self, config):
-        self.assertEqual(config.get('bucket_prefix'),
-                         self.expected_bucket_prefix)
-        return self.riak_manager
+    def get_riak_manager(self, config):
+        self.assertEqual(config["bucket_prefix"], self.expected_bucket_prefix)
+        return self.persistence_helper.get_riak_manager(config)
+
+    def recorded_loads_and_stores(self, model_migrator):
+        return model_migrator.recorded_loads, model_migrator.recorded_stores
 
     def mk_simple_models(self, n):
         for i in range(n):
             obj = self.model(u"key-%d" % i, a=u"value-%d" % i)
             obj.save()
-
-    def record_load_and_store(self):
-        loads, stores = [], []
-        orig_load = self.riak_manager.load
-
-        def record_load(modelcls, key, result=None):
-            loads.append(key)
-            return orig_load(modelcls, key, result=result)
-
-        self.patch(self.riak_manager, 'load', record_load)
-
-        def record_store(obj):
-            stores.append(obj.key)
-
-        self.patch(self.riak_manager, 'store', record_store)
-        return loads, stores
 
     def test_model_class_required(self):
         self.assertRaises(usage.UsageError, self.make_migrator, [
@@ -85,8 +83,8 @@ class TestModelMigrator(VumiTestCase):
 
     def test_successful_migration(self):
         self.mk_simple_models(3)
-        loads, stores = self.record_load_and_store()
         cfg = self.make_migrator()
+        loads, stores = self.recorded_loads_and_stores(cfg)
         cfg.run()
         self.assertEqual(cfg.output, [
             "3 keys found. Migrating ...",
@@ -102,9 +100,7 @@ class TestModelMigrator(VumiTestCase):
         def tombstone_load(modelcls, key, result=None):
             return None
 
-        self.patch(self.riak_manager, 'load', tombstone_load)
-
-        cfg = self.make_migrator()
+        cfg = self.make_migrator(manager_load_func=tombstone_load)
         cfg.run()
         for i in range(3):
             self.assertTrue(("Skipping tombstone key u'key-%d'." % i)
@@ -123,9 +119,7 @@ class TestModelMigrator(VumiTestCase):
         def error_load(modelcls, key, result=None):
             raise ValueError("Failed to load.")
 
-        self.patch(self.riak_manager, 'load', error_load)
-
-        cfg = self.make_migrator()
+        cfg = self.make_migrator(manager_load_func=error_load)
         cfg.run()
         line_pairs = zip(cfg.output, cfg.output[1:])
         for i in range(3):
@@ -143,8 +137,8 @@ class TestModelMigrator(VumiTestCase):
 
     def test_migrating_specific_keys(self):
         self.mk_simple_models(3)
-        loads, stores = self.record_load_and_store()
         cfg = self.make_migrator(self.default_args + ["--keys", "key-1,key-2"])
+        loads, stores = self.recorded_loads_and_stores(cfg)
         cfg.run()
         self.assertEqual(cfg.output, [
             "Migrating 2 specified keys ...",
@@ -156,8 +150,8 @@ class TestModelMigrator(VumiTestCase):
 
     def test_dry_run(self):
         self.mk_simple_models(3)
-        loads, stores = self.record_load_and_store()
         cfg = self.make_migrator(self.default_args + ["--dry-run"])
+        loads, stores = self.recorded_loads_and_stores(cfg)
         cfg.run()
         self.assertEqual(cfg.output, [
             "3 keys found. Migrating ...",

--- a/vumi/tests/helpers.py
+++ b/vumi/tests/helpers.py
@@ -1399,7 +1399,7 @@ class PersistenceHelper(object):
                 "setup() must be called before performing this operation.")
 
     @proxyable
-    def get_riak_manager(self, config=None):
+    def get_riak_manager(self, config=None, prepend_bucket_prefix=True):
         """
         Build and return a Riak manager.
 
@@ -1407,14 +1407,25 @@ class PersistenceHelper(object):
             Riak manager config. (Not a complete worker config.) If ``None``,
             the one used by :meth:`mk_config` will be used.
 
+        :param bool prepend_bucket_prefix:
+            If ``True`` (the default), the ``bucket_prefix`` field in the given
+            config (if any) will have the test prefix prepended to it. To keep
+            the ``bucket_prefix`` unmodified, set this to ``False``.
+
         :returns:
             A :class:`~vumi.persist.riak_manager.RiakManager` or
             :class:`~vumi.persist.riak_manager.TxRiakManager`, depending on the
             value of :attr:`is_sync`.
         """
         self._check_patches_applied()
+        default_config = self._config_overrides["riak_manager"].copy()
         if config is None:
-            config = self._config_overrides['riak_manager'].copy()
+            config = default_config
+        else:
+            config = config.copy()
+            if prepend_bucket_prefix:
+                config["bucket_prefix"] = "%s%s" % (
+                    default_config["bucket_prefix"], config["bucket_prefix"])
 
         if self.is_sync:
             return self._get_sync_riak_manager(config)

--- a/vumi/tests/helpers.py
+++ b/vumi/tests/helpers.py
@@ -1232,13 +1232,14 @@ class PersistenceHelper(object):
         self._patches = []
         self._riak_managers = []
         self._redis_managers = []
+        self._test_prefix = 'vumitest'
         self._config_overrides = {
             'redis_manager': {
                 'FAKE_REDIS': 'yes',
-                'key_prefix': 'vumitest',
+                'key_prefix': self._test_prefix,
             },
             'riak_manager': {
-                'bucket_prefix': 'vumitest',
+                'bucket_prefix': self._test_prefix,
             },
         }
         if not self.use_riak:
@@ -1399,7 +1400,7 @@ class PersistenceHelper(object):
                 "setup() must be called before performing this operation.")
 
     @proxyable
-    def get_riak_manager(self, config=None, prepend_bucket_prefix=True):
+    def get_riak_manager(self, config=None):
         """
         Build and return a Riak manager.
 
@@ -1407,25 +1408,18 @@ class PersistenceHelper(object):
             Riak manager config. (Not a complete worker config.) If ``None``,
             the one used by :meth:`mk_config` will be used.
 
-        :param bool prepend_bucket_prefix:
-            If ``True`` (the default), the ``bucket_prefix`` field in the given
-            config (if any) will have the test prefix prepended to it. To keep
-            the ``bucket_prefix`` unmodified, set this to ``False``.
-
         :returns:
             A :class:`~vumi.persist.riak_manager.RiakManager` or
             :class:`~vumi.persist.riak_manager.TxRiakManager`, depending on the
             value of :attr:`is_sync`.
         """
         self._check_patches_applied()
-        default_config = self._config_overrides["riak_manager"].copy()
         if config is None:
-            config = default_config
+            config = self._config_overrides["riak_manager"].copy()
         else:
             config = config.copy()
-            if prepend_bucket_prefix:
-                config["bucket_prefix"] = "%s%s" % (
-                    default_config["bucket_prefix"], config["bucket_prefix"])
+            config["bucket_prefix"] = "%s%s" % (
+                self._test_prefix, config["bucket_prefix"])
 
         if self.is_sync:
             return self._get_sync_riak_manager(config)

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -1729,16 +1729,6 @@ class TestPersistenceHelper(VumiTestCase):
         manager = persistence_helper.get_riak_manager({"bucket_prefix": "foo"})
         self.assertEqual(manager.bucket_prefix, "vumitestfoo")
 
-    def test_get_riak_manager_with_config_no_prepend(self):
-        """
-        .get_riak_manager(config, False) returns a manager created using the
-        provided config, with the bucket_prefix field unmodified.
-        """
-        persistence_helper = self.add_helper(PersistenceHelper(use_riak=True))
-        manager = persistence_helper.get_riak_manager(
-            {"bucket_prefix": "foo"}, prepend_bucket_prefix=False)
-        self.assertEqual(manager.bucket_prefix, "foo")
-
     def test_get_redis_manager_sync(self):
         """
         .get_redis_manager() should return a RedisManager if ``is_sync`` is

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -1720,6 +1720,25 @@ class TestPersistenceHelper(VumiTestCase):
         self.assertIsInstance(manager, self._TxRiakManager)
         self.assertEqual(persistence_helper._riak_managers, [manager])
 
+    def test_get_riak_manager_with_config(self):
+        """
+        .get_riak_manager(config) returns a manager created using the provided
+        config, with "vumitest" prepended to the bucket_prefix field.
+        """
+        persistence_helper = self.add_helper(PersistenceHelper(use_riak=True))
+        manager = persistence_helper.get_riak_manager({"bucket_prefix": "foo"})
+        self.assertEqual(manager.bucket_prefix, "vumitestfoo")
+
+    def test_get_riak_manager_with_config_no_prepend(self):
+        """
+        .get_riak_manager(config, False) returns a manager created using the
+        provided config, with the bucket_prefix field unmodified.
+        """
+        persistence_helper = self.add_helper(PersistenceHelper(use_riak=True))
+        manager = persistence_helper.get_riak_manager(
+            {"bucket_prefix": "foo"}, prepend_bucket_prefix=False)
+        self.assertEqual(manager.bucket_prefix, "foo")
+
     def test_get_redis_manager_sync(self):
         """
         .get_redis_manager() should return a RedisManager if ``is_sync`` is


### PR DESCRIPTION
Trying to properly clean up Riak managers (and assert that the cleanup is happening) has uncovered problems with how we handle Riak managers in various scripts. This is separate from the work in #950, but necessary for it.