### PR TITLE
Factor out common Riak wrapper code

### DIFF
--- a/vumi/persist/model.py
+++ b/vumi/persist/model.py
@@ -740,6 +740,45 @@ class Manager(object):
         raise NotImplementedError("Sub-classes of Manager should implement"
                                   " .load(...)")
 
+    def _migrate_riak_object(self, modelcls, key, riak_object):
+        """
+        Migrate a loaded riak_object to the latest schema version.
+
+        NOTE: This should only be called by subclasses.
+        """
+        was_migrated = False
+
+        # Run migrators until we have the correct version of the data.
+        while riak_object.get_data() is not None:
+            data_version = riak_object.get_data().get('$VERSION', None)
+            if data_version == modelcls.VERSION:
+                obj = modelcls(self, key, _riak_object=riak_object)
+                obj.was_migrated = was_migrated
+                return obj
+            migrator = modelcls.MIGRATOR(modelcls, self, data_version)
+            riak_object = migrator(riak_object).get_riak_object()
+            was_migrated = True
+        return None
+
+    def _reverse_migrate_riak_object(self, modelobj):
+        """
+        Migrate a riak_object to the required schema version before storing.
+
+        NOTE: This should only be called by subclasses.
+        """
+        riak_object = modelobj._riak_object
+        modelcls = type(modelobj)
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        store_version = self.store_versions.get(model_name, modelcls.VERSION)
+        # Run reverse migrators until we have the correct version of the data.
+        data_version = riak_object.get_data().get('$VERSION', None)
+        while data_version != store_version:
+            migrator = modelcls.MIGRATOR(
+                modelcls, self, data_version, reverse=True)
+            riak_object = migrator(riak_object).get_riak_object()
+            data_version = riak_object.get_data().get('$VERSION', None)
+        return riak_object
+
     def _load_multiple(self, cls, keys):
         """Load the model instances for a batch of keys from Riak.
 

--- a/vumi/persist/riak_base.py
+++ b/vumi/persist/riak_base.py
@@ -5,13 +5,13 @@ import json
 from riak import RiakClient
 
 
-def to_unicode(text, encoding='utf-8'):
+def _to_unicode(text, encoding='utf-8'):
     # If we already have unicode or `None`, there's nothing to do.
     if isinstance(text, (unicode, type(None))):
         return text
     # If we have a tuple, we need to do our thing with every element in it.
     if isinstance(text, tuple):
-        return tuple(to_unicode(item, encoding) for item in text)
+        return tuple(_to_unicode(item, encoding) for item in text)
     # If we get here, then we should have a bytestring.
     return text.decode(encoding)
 
@@ -86,7 +86,7 @@ class VumiIndexPageBase(object):
     def __iter__(self):
         if self._index_page.stream:
             raise NotImplementedError("Streaming is not currently supported.")
-        return (to_unicode(item) for item in self._index_page)
+        return (_to_unicode(item) for item in self._index_page)
 
     def __eq__(self, other):
         return self._index_page.__eq__(other)
@@ -103,7 +103,7 @@ class VumiIndexPageBase(object):
 
     @property
     def continuation(self):
-        return to_unicode(self._index_page.continuation)
+        return _to_unicode(self._index_page.continuation)
 
     # Methods that touch the network.
 

--- a/vumi/persist/riak_base.py
+++ b/vumi/persist/riak_base.py
@@ -1,0 +1,208 @@
+"""Basic tools for building a Riak manager."""
+
+import json
+
+from riak import RiakClient
+
+
+def to_unicode(text, encoding='utf-8'):
+    if text is None:
+        return text
+    if isinstance(text, tuple):
+        return tuple(to_unicode(item, encoding) for item in text)
+    if not isinstance(text, unicode):
+        return text.decode(encoding)
+    return text
+
+
+class VumiRiakClientBase(object):
+    """
+    Wrapper around a RiakClient to manage resources better.
+    """
+
+    def __init__(self, **client_args):
+        self._client = RiakClient(**client_args)
+        # Some versions of the riak client library use simplejson by
+        # preference, which breaks some of our unicode assumptions. This makes
+        # sure we're using stdlib json which doesn't sometimes return
+        # bytestrings instead of unicode.
+        self._client.set_encoder('application/json', json.dumps)
+        self._client.set_encoder('text/json', json.dumps)
+        self._client.set_decoder('application/json', json.loads)
+        self._client.set_decoder('text/json', json.loads)
+
+        self._closed = False
+
+    @property
+    def protocol(self):
+        return self._client.protocol
+
+    def close(self):
+        self._closed = True
+        return self._client.close()
+
+    def bucket(self, bucket_name):
+        return self._client.bucket(bucket_name)
+
+    def put(self, *args, **kw):
+        return self._client.put(*args, **kw)
+
+    def get(self, *args, **kw):
+        return self._client.get(*args, **kw)
+
+    def delete(self, *args, **kw):
+        return self._client.delete(*args, **kw)
+
+    def mapred(self, *args, **kw):
+        return self._client.mapred(*args, **kw)
+
+    def _purge_all(self, bucket_prefix):
+        """
+        Purge all objects and buckets properties belonging to buckets with the
+        given prefix.
+
+        NOTE: This operation should *ONLY* be used in tests.
+        """
+        buckets = self._client.get_buckets()
+        for bucket in buckets:
+            if bucket.name.startswith(bucket_prefix):
+                for key in bucket.get_keys():
+                    obj = bucket.get(key)
+                    obj.delete()
+                bucket.clear_properties()
+
+
+class VumiIndexPageBase(object):
+    """
+    Wrapper around a page of index query results.
+
+    Iterating over this object will return the results for the current page.
+    """
+
+    def __init__(self, index_page):
+        self._index_page = index_page
+
+    def __iter__(self):
+        if self._index_page.stream:
+            raise NotImplementedError("Streaming is not currently supported.")
+        return (to_unicode(item) for item in self._index_page)
+
+    def __eq__(self, other):
+        return self._index_page.__eq__(other)
+
+    def has_next_page(self):
+        """
+        Indicate whether there are more results to follow.
+
+        :returns:
+            ``True`` if there are more results, ``False`` if this is the last
+            page.
+        """
+        return self._index_page.has_next_page()
+
+    @property
+    def continuation(self):
+        return to_unicode(self._index_page.continuation)
+
+    # Methods that touch the network.
+
+    def next_page(self):
+        raise NotImplementedError("Subclasses must implement this.")
+
+
+class VumiRiakBucketBase(object):
+    """
+    Wrapper around a RiakBucket to manage network access better.
+    """
+
+    def __init__(self, riak_bucket):
+        self._riak_bucket = riak_bucket
+
+    def get_name(self):
+        return self._riak_bucket.name
+
+    # Methods that touch the network.
+
+    def get_index(self, index_name, start_value, end_value=None,
+                  return_terms=None):
+        raise NotImplementedError("Subclasses must implement this.")
+
+    def get_index_page(self, index_name, start_value, end_value=None,
+                       return_terms=None, max_results=None, continuation=None):
+        raise NotImplementedError("Subclasses must implement this.")
+
+
+class VumiRiakObjectBase(object):
+    """
+    Wrapper around a RiakObject to manage network access better.
+    """
+
+    def __init__(self, riak_obj):
+        self._riak_obj = riak_obj
+
+    @property
+    def key(self):
+        return self._riak_obj.key
+
+    def get_key(self):
+        return self.key
+
+    def get_content_type(self):
+        return self._riak_obj.content_type
+
+    def set_content_type(self, content_type):
+        self._riak_obj.content_type = content_type
+
+    def get_data(self):
+        return self._riak_obj.data
+
+    def set_data(self, data):
+        self._riak_obj.data = data
+
+    def set_encoded_data(self, encoded_data):
+        self._riak_obj.encoded_data = encoded_data
+
+    def set_data_field(self, key, value):
+        self._riak_obj.data[key] = value
+
+    def delete_data_field(self, key):
+        del self._riak_obj.data[key]
+
+    def get_indexes(self):
+        return self._riak_obj.indexes
+
+    def set_indexes(self, indexes):
+        self._riak_obj.indexes = indexes
+
+    def add_index(self, index_name, index_value):
+        self._riak_obj.add_index(index_name, index_value)
+
+    def remove_index(self, index_name, index_value=None):
+        self._riak_obj.remove_index(index_name, index_value)
+
+    def get_user_metadata(self):
+        return self._riak_obj.usermeta
+
+    def set_user_metadata(self, usermeta):
+        self._riak_obj.usermeta = usermeta
+
+    def get_bucket(self):
+        raise NotImplementedError("Subclasses must implement this.")
+
+    # Methods that touch the network.
+
+    def _call_and_wrap(self, func):
+        """
+        Call a function that touches the network and wrap the result in this
+        class.
+        """
+        raise NotImplementedError("Subclasses must implement this.")
+
+    def store(self):
+        return self._call_and_wrap(self._riak_obj.store)
+
+    def reload(self):
+        return self._call_and_wrap(self._riak_obj.reload)
+
+    def delete(self):
+        return self._call_and_wrap(self._riak_obj.delete)

--- a/vumi/persist/riak_base.py
+++ b/vumi/persist/riak_base.py
@@ -6,13 +6,14 @@ from riak import RiakClient
 
 
 def to_unicode(text, encoding='utf-8'):
-    if text is None:
+    # If we already have unicode or `None`, there's nothing to do.
+    if isinstance(text, (unicode, type(None))):
         return text
+    # If we have a tuple, we need to do our thing with every element in it.
     if isinstance(text, tuple):
         return tuple(to_unicode(item, encoding) for item in text)
-    if not isinstance(text, unicode):
-        return text.decode(encoding)
-    return text
+    # If we get here, then we should have a bytestring.
+    return text.decode(encoding)
 
 
 class VumiRiakClientBase(object):

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -161,17 +161,7 @@ class TxRiakManager(Manager):
         return riak_object
 
     def store(self, modelobj):
-        riak_object = modelobj._riak_object
-        modelcls = type(modelobj)
-        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
-        store_version = self.store_versions.get(model_name, modelcls.VERSION)
-        # Run reverse migrators until we have the correct version of the data.
-        data_version = riak_object.get_data().get('$VERSION', None)
-        while data_version != store_version:
-            migrator = modelcls.MIGRATOR(
-                modelcls, self, data_version, reverse=True)
-            riak_object = migrator(riak_object).get_riak_object()
-            data_version = riak_object.get_data().get('$VERSION', None)
+        riak_object = self._reverse_migrate_riak_object(modelobj)
         d = riak_object.store()
         d.addCallback(lambda _: modelobj)
         return d
@@ -186,19 +176,7 @@ class TxRiakManager(Manager):
         riak_object = self.riak_object(modelcls, key, result)
         if not result:
             yield riak_object.reload()
-        was_migrated = False
-
-        # Run migrators until we have the correct version of the data.
-        while riak_object.get_data() is not None:
-            data_version = riak_object.get_data().get('$VERSION', None)
-            if data_version == modelcls.VERSION:
-                obj = modelcls(self, key, _riak_object=riak_object)
-                obj.was_migrated = was_migrated
-                returnValue(obj)
-            migrator = modelcls.MIGRATOR(modelcls, self, data_version)
-            riak_object = migrator(riak_object).get_riak_object()
-            was_migrated = True
-        returnValue(None)
+        returnValue(self._migrate_riak_object(modelcls, key, riak_object))
 
     def _load_multiple(self, modelcls, keys):
         d = gatherResults([self.load(modelcls, key) for key in keys])

--- a/vumi/persist/txriak_manager.py
+++ b/vumi/persist/txriak_manager.py
@@ -2,24 +2,15 @@
 
 """An async manager implementation on top of the riak Python package."""
 
-import json
-
-from riak import RiakClient, RiakObject, RiakMapReduce, RiakError
+from riak import RiakObject, RiakMapReduce, RiakError
 from twisted.internet.threads import deferToThread
 from twisted.internet.defer import (
     inlineCallbacks, returnValue, gatherResults, maybeDeferred, succeed)
 
 from vumi.persist.model import Manager, VumiRiakError
-
-
-def to_unicode(text, encoding='utf-8'):
-    if text is None:
-        return text
-    if isinstance(text, tuple):
-        return tuple(to_unicode(item, encoding) for item in text)
-    if not isinstance(text, unicode):
-        return text.decode(encoding)
-    return text
+from vumi.persist.riak_base import (
+    VumiRiakClientBase, VumiIndexPageBase, VumiRiakBucketBase,
+    VumiRiakObjectBase)
 
 
 def riakErrorHandler(failure):
@@ -27,37 +18,18 @@ def riakErrorHandler(failure):
     raise VumiRiakError(e)
 
 
-class VumiTxIndexPage(object):
+class VumiTxRiakClient(VumiRiakClientBase):
+    """
+    Wrapper around a RiakClient to manage resources better.
+    """
+
+
+class VumiTxIndexPage(VumiIndexPageBase):
     """
     Wrapper around a page of index query results.
 
     Iterating over this object will return the results for the current page.
     """
-
-    def __init__(self, index_page):
-        self._index_page = index_page
-
-    def __iter__(self):
-        if self._index_page.stream:
-            raise NotImplementedError("Streaming is not currently supported.")
-        return (to_unicode(item) for item in self._index_page)
-
-    def __eq__(self, other):
-        return self._index_page.__eq__(other)
-
-    def has_next_page(self):
-        """
-        Indicate whether there are more results to follow.
-
-        :returns:
-            ``True`` if there are more results, ``False`` if this is the last
-            page.
-        """
-        return self._index_page.has_next_page()
-
-    @property
-    def continuation(self):
-        return to_unicode(self._index_page.continuation)
 
     # Methods that touch the network.
 
@@ -77,12 +49,10 @@ class VumiTxIndexPage(object):
         return d
 
 
-class VumiTxRiakBucket(object):
-    def __init__(self, riak_bucket):
-        self._riak_bucket = riak_bucket
-
-    def get_name(self):
-        return self._riak_bucket.name
+class VumiTxRiakBucket(VumiRiakBucketBase):
+    """
+    Wrapper around a RiakBucket to manage network access better.
+    """
 
     # Methods that touch the network.
 
@@ -104,73 +74,22 @@ class VumiTxRiakBucket(object):
         return d
 
 
-class VumiTxRiakObject(object):
-    def __init__(self, riak_obj):
-        self._riak_obj = riak_obj
-
-    @property
-    def key(self):
-        return self._riak_obj.key
-
-    def get_key(self):
-        return self.key
-
-    def get_content_type(self):
-        return self._riak_obj.content_type
-
-    def set_content_type(self, content_type):
-        self._riak_obj.content_type = content_type
-
-    def get_data(self):
-        return self._riak_obj.data
-
-    def set_data(self, data):
-        self._riak_obj.data = data
-
-    def set_encoded_data(self, encoded_data):
-        self._riak_obj.encoded_data = encoded_data
-
-    def set_data_field(self, key, value):
-        self._riak_obj.data[key] = value
-
-    def delete_data_field(self, key):
-        del self._riak_obj.data[key]
-
-    def get_indexes(self):
-        return self._riak_obj.indexes
-
-    def set_indexes(self, indexes):
-        self._riak_obj.indexes = indexes
-
-    def add_index(self, index_name, index_value):
-        self._riak_obj.add_index(index_name, index_value)
-
-    def remove_index(self, index_name, index_value=None):
-        self._riak_obj.remove_index(index_name, index_value)
-
-    def get_user_metadata(self):
-        return self._riak_obj.usermeta
-
-    def set_user_metadata(self, usermeta):
-        self._riak_obj.usermeta = usermeta
+class VumiTxRiakObject(VumiRiakObjectBase):
+    """
+    Wrapper around a RiakObject to manage network access better.
+    """
 
     def get_bucket(self):
         return VumiTxRiakBucket(self._riak_obj.bucket)
 
     # Methods that touch the network.
 
-    def store(self):
-        d = deferToThread(self._riak_obj.store)
-        d.addCallback(type(self))
-        return d
-
-    def reload(self):
-        d = deferToThread(self._riak_obj.reload)
-        d.addCallback(type(self))
-        return d
-
-    def delete(self):
-        d = deferToThread(self._riak_obj.delete)
+    def _call_and_wrap(self, func):
+        """
+        Call a function that touches the network and wrap the result in this
+        class.
+        """
+        d = deferToThread(func)
         d.addCallback(type(self))
         return d
 
@@ -206,15 +125,7 @@ class TxRiakManager(Manager):
         if port is not None:
             client_args['port'] = port
 
-        client = RiakClient(**client_args)
-        # Some versions of the riak client library use simplejson by
-        # preference, which breaks some of our unicode assumptions. This makes
-        # sure we're using stdlib json which doesn't sometimes return
-        # bytestrings instead of unicode.
-        client.set_encoder('application/json', json.dumps)
-        client.set_encoder('text/json', json.dumps)
-        client.set_decoder('application/json', json.loads)
-        client.set_decoder('text/json', json.loads)
+        client = VumiTxRiakClient(**client_args)
         return cls(
             client, bucket_prefix, load_bunch_size=load_bunch_size,
             mapreduce_timeout=mapreduce_timeout, store_versions=store_versions)
@@ -353,24 +264,5 @@ class TxRiakManager(Manager):
     def should_quote_index_values(self):
         return False
 
-    @inlineCallbacks
     def purge_all(self):
-        def delete_obj(bucket, key):
-            # These are sync operations
-            obj = bucket.get(key)
-            obj.delete()
-
-        def purge_bucket(bucket):
-            key_deletes = []
-            for key in bucket.get_keys():
-                key_deletes.append(deferToThread(delete_obj, bucket, key))
-            d = gatherResults(key_deletes)
-            d.addCallback(lambda _: deferToThread(bucket.clear_properties))
-            return d
-
-        bucket_deletes = []
-        buckets = yield deferToThread(self.client.get_buckets)
-        for bucket in buckets:
-            if bucket.name.startswith(self.bucket_prefix):
-                bucket_deletes.append(purge_bucket(bucket))
-        yield gatherResults(bucket_deletes)
+        return deferToThread(self.client._purge_all, self.bucket_prefix)


### PR DESCRIPTION
`RiakManager` and `TxRiakManager` both have a lot of wrapper code around the underlying library objects, and there's a bunch of duplication here. This issue is for factoring out the common bits and adding a new wrapper around the client object that we can add extra things to later.

(This is another case of pulling a piece of the big Riak manager cleanup/threadpool/whatever mudball out into its own smaller change.)