### PR TITLE
Implement `__len__()` in wrapped Riak page objects

### DIFF
--- a/vumi/persist/riak_base.py
+++ b/vumi/persist/riak_base.py
@@ -102,6 +102,9 @@ class VumiIndexPageBase(object):
             raise NotImplementedError("Streaming is not currently supported.")
         return (_to_unicode(item) for item in self._index_page)
 
+    def __len__(self):
+        return len(self._index_page)
+
     def __eq__(self, other):
         return self._index_page.__eq__(other)
 

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -749,6 +749,35 @@ class ModelTestMixin(object):
             pass
 
     @Manager.calls_manager
+    def test_index_keys_page_length(self):
+        """
+        The length function for the page returns the correct length for two
+        pages of different length.
+        """
+        indexed_model = self.manager.proxy(IndexedModel)
+        yield indexed_model("foo1", a=1, b=u"one").save()
+        yield indexed_model("foo2", a=1, b=u"one").save()
+        yield indexed_model("foo3", a=1, b=None).save()
+
+        keys1 = yield indexed_model.index_keys_page('a', 1, max_results=2)
+        self.assertEqual(len(keys1), 2)
+
+        keys2 = yield keys1.next_page()
+        self.assertEqual(len(keys2), 1)
+
+    @Manager.calls_manager
+    def test_index_keys_empty_page_length(self):
+        """
+        The length function for the page returns a length of 0 for an empty
+        page.
+        """
+        indexed_model = self.manager.proxy(IndexedModel)
+        yield indexed_model("foo1", a=2, b=u"one").save()
+
+        keys1 = yield indexed_model.index_keys_page('a', 1)
+        self.assertEqual(len(keys1), 0)
+
+    @Manager.calls_manager
     def test_index_keys_quoting(self):
         indexed_model = self.manager.proxy(IndexedModel)
         yield indexed_model("foo1", a=1, b=u"+one").save()

--- a/vumi/persist/tests/test_model.py
+++ b/vumi/persist/tests/test_model.py
@@ -673,7 +673,7 @@ class ModelTestMixin(object):
         while keys_page is not None:
             keys.extend(list(keys_page))
             if keys_page.has_next_page():
-                self.assertEqual(len(list(keys_page)), 1)
+                self.assertEqual(len(keys_page), 1)
                 keys_page = yield keys_page.next_page()
             else:
                 keys_page = None


### PR DESCRIPTION
The underlying Riak client library objects implement `__len__()` so this should be possible. This should be a small optimisation for counting the length of items in a page (which doesn't happen that often).

Class of interest is `vumi.persist.riak_base.VumiIndexPageBase`