### PR TITLE
Accept empty SMSes and pass them on as empty strings.

### DIFF
--- a/vumi/transports/smpp/processors/mica.py
+++ b/vumi/transports/smpp/processors/mica.py
@@ -75,7 +75,8 @@ class DeliverShortMessageProcessor(default.DeliverShortMessageProcessor):
             session = yield self.session_manager.load_session(
                 vumi_session_identifier)
             ussd_code = session['ussd_code']
-            content = pdu_params['short_message']
+            content = self.dcs_decode(
+                pdu_params['short_message'], pdu_params['data_coding'])
 
         # This is stashed on the message and available when replying
         # with a `submit_sm`
@@ -84,13 +85,10 @@ class DeliverShortMessageProcessor(default.DeliverShortMessageProcessor):
             'session_identifier': mica_session_identifier,
         }
 
-        decoded_msg = self.dcs_decode(content,
-                                      pdu_params['data_coding'])
-
         result = yield self.handle_short_message_content(
             source_addr=pdu_params['source_addr'],
             destination_addr=ussd_code,
-            short_message=decoded_msg,
+            short_message=content,
             message_type='ussd',
             session_event=session_event,
             session_info=session_info)

--- a/vumi/transports/smpp/processors/sixdee.py
+++ b/vumi/transports/smpp/processors/sixdee.py
@@ -86,7 +86,8 @@ class DeliverShortMessageProcessor(default.DeliverShortMessageProcessor):
             session = yield self.session_manager.load_session(
                 vumi_session_identifier)
             ussd_code = session['ussd_code']
-            content = pdu_params['short_message']
+            content = self.dcs_decode(
+                pdu_params['short_message'], pdu_params['data_coding'])
 
         # This is stashed on the message and available when replying
         # with a `submit_sm`
@@ -95,13 +96,10 @@ class DeliverShortMessageProcessor(default.DeliverShortMessageProcessor):
             'session_identifier': sixdee_session_identifier,
         }
 
-        decoded_msg = self.dcs_decode(content,
-                                      pdu_params['data_coding'])
-
         result = yield self.handle_short_message_content(
             source_addr=pdu_params['source_addr'],
             destination_addr=ussd_code,
-            short_message=decoded_msg,
+            short_message=content,
             message_type='ussd',
             session_event=session_event,
             session_info=session_info)


### PR DESCRIPTION
It appears that some phones and networks support sending empty SMSes. We currently reject those but should probably forward them on as empty messages.