### PR TITLE
Old cryptography for old pypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,13 @@
+import platform
+import sys
 from setuptools import setup, find_packages
+
+
+# cryptography>=1.0 requires pypy>=2.6.0 because of the new cffi stuff.
+cryptography = 'cryptography'
+if platform.python_implementation() == "PyPy":
+    if sys.pypy_version_info < (2, 6):
+        cryptography = 'cryptography<1.0'
 
 
 setup(
@@ -25,6 +34,7 @@ setup(
         'vumi/scripts/vumi_list_messages.py',
     ],
     install_requires=[
+        cryptography,  # See above for pypy-version-dependent requirement.
         'zope.interface',
         'Twisted>=13.1.0',
         'txAMQP>=0.6.2',


### PR DESCRIPTION
`cryptography>=1.0` only supports pypy 2.6.0 and later. Travis has an older pypy than that, so builds fail.

The plan is to detect old pypy in `setup.py` and add a constraint on the `cryptography` version.