### PR TITLE
Fix Riak race condition in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - $HOME/riak/bin/riak-admin member-status
 script:
   - if [ -z "$NO_COVERAGE" ]; then COVERAGE_CMD="coverage run --source=vumi"; else COVERAGE_CMD=""; fi
-  - VUMI_TEST_ASSERT_CLOSED=true VUMI_TEST_TIMEOUT=10 VUMITEST_REDIS_DB=1 VUMI_TEST_NODE_PATH="$(which node)" $COVERAGE_CMD `which trial` vumi
+  - VUMI_TEST_ASSERT_CLOSED=true VUMI_TEST_TIMEOUT=20 VUMITEST_REDIS_DB=1 VUMI_TEST_NODE_PATH="$(which node)" $COVERAGE_CMD `which trial` vumi
 
 after_success:
   - if [ -z "$NO_COVERAGE" ]; then coveralls; fi


### PR DESCRIPTION
`TestMessageStoreResource.test_disconnect_kills_server` leaves some unfinished Riak operations running, which results in a race condition on cleanup and occasional build failures.