### PR TITLE
Better SMPP multipart_info handling

### DIFF
--- a/vumi/transports/smpp/config.py
+++ b/vumi/transports/smpp/config.py
@@ -37,6 +37,11 @@ class SmppTransportConfig(Transport.CONFIG_CLASS):
         'for matching submit_sm_resp and delivery report messages. Defaults '
         'to 1 week.',
         default=(60 * 60 * 24 * 7), static=True)
+    completed_multipart_info_expiry = ConfigInt(
+        'How long (in seconds) to keep multipart message info for completed '
+        'multipart messages around to avoid pending operations accidentally '
+        'recreating them without an expiry time. Defaults to 1 hour.',
+        default=(60 * 60), static=True)
     redis_manager = ConfigDict(
         'How to connect to Redis.', default={}, static=True)
     split_bind_prefix = ConfigText(

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -421,10 +421,10 @@ class SmppTransceiverTransport(Transport):
     def process_submit_sm_event(self, message_id, event_type, remote_id,
                                 command_status):
         if event_type == 'ack':
-            if not self.disable_ack:
-                yield self.publish_ack(message_id, remote_id)
             yield self.message_stash.delete_cached_message(message_id)
             yield self.message_stash.expire_multipart_info(message_id)
+            if not self.disable_ack:
+                yield self.publish_ack(message_id, remote_id)
         else:
             if event_type != 'fail':
                 log.warning(

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -160,7 +160,7 @@ class SmppMessageDataStash(object):
 
     def init_multipart_info(self, message_id, part_count):
         key = multipart_info_key(message_id)
-        expiry = self.config.third_party_id_expiry
+        expiry = self.config.submit_sm_expiry
         d = self.redis.hmset(key, {
             'parts': part_count,
         })


### PR DESCRIPTION
At the moment, this uses the week-long `third_party_id_expiry` and is never cleared. Instead it should use the day-log `submit_sm_expiry` and be cleared after all parts of a message have been acknowledged.

(There may be some overlap with #965, but running out of memory in Redis is a worse problem than potential extra acks.)