### PR TITLE
Fix SMPP sequence number to message id TTL

### DIFF
--- a/vumi/transports/smpp/protocol.py
+++ b/vumi/transports/smpp/protocol.py
@@ -332,6 +332,9 @@ class EsmeProtocol(Protocol):
         d.addCallback(
             self._handle_submit_sm_resp_callback, smpp_message_id,
             command_status, cb)
+        d.addCallback(
+            lambda _: message_stash.delete_sequence_number_message_id(
+                sequence_number))
         return d
 
     def _handle_submit_sm_resp_callback(self, message_id, smpp_message_id,

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -191,11 +191,14 @@ class SmppMessageDataStash(object):
 
     def set_sequence_number_message_id(self, sequence_number, message_id):
         key = sequence_number_key(sequence_number)
-        expiry = self.config.third_party_id_expiry
+        expiry = self.config.submit_sm_expiry
         return self.redis.setex(key, expiry, message_id)
 
     def get_sequence_number_message_id(self, sequence_number):
         return self.redis.get(sequence_number_key(sequence_number))
+
+    def delete_sequence_number_message_id(self, sequence_number):
+        return self.redis.delete(sequence_number_key(sequence_number))
 
     def cache_message(self, message):
         key = message_key(message['message_id'])


### PR DESCRIPTION
Like #968, but for the `sequence_number` key.