### PR TITLE
Don't set SMPP remote message ids for failure responses

### DIFF
--- a/vumi/transports/smpp/protocol.py
+++ b/vumi/transports/smpp/protocol.py
@@ -318,8 +318,14 @@ class EsmeProtocol(Protocol):
         """
         message_stash = self.service.message_stash
         d = message_stash.get_sequence_number_message_id(sequence_number)
-        d.addCallback(
-            message_stash.set_remote_message_id, smpp_message_id)
+
+        # only set the remote message id if the submission was successful, we
+        # use remote message ids for delivery reports, so we won't need remote
+        # message ids for failed submissions
+        if command_status == 'ESME_ROK':
+            d.addCallback(
+                message_stash.set_remote_message_id, smpp_message_id)
+
         d.addCallback(
             self._handle_submit_sm_resp_callback, smpp_message_id,
             command_status, sequence_number)


### PR DESCRIPTION
Currently, we store a mapping between remote message ids and our message ids in redis, and use this when we get a delivery report to publish a delivery report event with our message id. We don't need to do this for failure responses though, since they will never get a delivery report.