### PR TITLE
Clear remote message redis keys when we get delivery reports

### DIFF
--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -236,6 +236,10 @@ class SmppMessageDataStash(object):
     def get_internal_message_id(self, smpp_message_id):
         return self.redis.get(remote_message_key(smpp_message_id))
 
+    def delete_remote_message_id(self, smpp_message_id):
+        key = remote_message_key(smpp_message_id)
+        return self.redis.delete(key)
+
 
 class SmppTransceiverTransport(Transport):
 
@@ -402,6 +406,8 @@ class SmppTransceiverTransport(Transport):
         dr = yield self.publish_delivery_report(
             user_message_id=message_id,
             delivery_status=delivery_status)
+
+        yield self.message_stash.delete_remote_message_id(receipted_message_id)
         returnValue(dr)
 
 

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1490,6 +1490,21 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
                               "discarded." % self.tx_helper.transport_name,))
 
     @inlineCallbacks
+    def test_delivery_report_delete_stored_remote_id(self):
+        transport = yield self.get_transport()
+        yield transport.message_stash.set_remote_message_id('bar', 'foo')
+
+        pdu = DeliverSM(sequence_number=1, esm_class=4)
+        pdu.add_optional_parameter('receipted_message_id', 'foo')
+        pdu.add_optional_parameter('message_state', 2)
+        yield self.fake_smsc.handle_pdu(pdu)
+
+        yield self.tx_helper.wait_for_dispatched_events(1)
+
+        self.assertFalse(
+            (yield transport.redis.exists(remote_message_key('foo'))))
+
+    @inlineCallbacks
     def test_reconnect(self):
         transport = yield self.get_transport(bind=False)
         connector = transport.connectors[transport.transport_name]


### PR DESCRIPTION
Currently, we store a mapping between remote message ids and our message ids in redis, and use this when we get a delivery report to publish a delivery report event with our message id. Once we've published the delivery report event, we no longer need the remote message ids, yet we still keep them around for a week.