### PR TITLE
Infrastructure for publishing and consuming status events

### DIFF
--- a/vumi/connectors.py
+++ b/vumi/connectors.py
@@ -170,8 +170,8 @@ class PublishStatusConnector(BaseConnector):
     def setup(self):
         yield self._setup_publisher('status')
 
-    def publish_status(self, msg, endpoint_name=None):
-        return self._publish_message('status', msg, endpoint_name)
+    def publish_status(self, msg):
+        return self._publish_message('status', msg, endpoint_name=None)
 
 
 class ReceiveStatusConnector(BaseConnector):
@@ -183,8 +183,5 @@ class ReceiveStatusConnector(BaseConnector):
     def default_status_handler(self, msg):
         log.warning("No status handler for %r: %r" % (self.name, msg))
 
-    def set_status_handler(self, handler, endpoint_name=None):
-        self._set_endpoint_handler('status', handler, endpoint_name)
-
-    def set_default_status_handler(self, handler):
+    def set_status_handler(self, handler):
         self._set_default_endpoint_handler('status', handler)

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -429,3 +429,24 @@ class TransportEvent(TransportMessage):
             self.assert_field_present(extra_field)
             if not check(self[extra_field]):
                 raise InvalidMessageField(extra_field)
+
+
+class TransportStatus(TransportMessage):
+    """Message about a status event emitted by a transport.
+    """
+    MESSAGE_TYPE = 'status_event'
+    STATUSES = frozenset(('good', 'minor', 'major'))
+
+    def process_fields(self, fields):
+        super(TransportStatus, self).process_fields(fields)
+        fields.setdefault('reasons', [])
+        fields.setdefault('details', {})
+        return fields
+
+    def validate_fields(self):
+        super(TransportStatus, self).validate_fields()
+        self.assert_field_present('status')
+
+        if self.payload['status'] not in self.STATUSES:
+            raise InvalidMessageField(
+                "Unknown status %r" % (self.payload['status'],))

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -2,7 +2,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.connectors import (
     BaseConnector, ReceiveInboundConnector, ReceiveOutboundConnector,
-    IgnoreMessage)
+    PublishStatusConnector, ReceiveStatusConnector, IgnoreMessage)
 from vumi.tests.utils import LogCatcher
 from vumi.worker import BaseWorker
 from vumi.message import TransportUserMessage
@@ -386,3 +386,51 @@ class TestReceiveOutboundConnector(BaseConnectorTestCase):
                 "Ignoring msg (with NACK) due to IgnoreMessage(): <Message"))
         [event] = self.worker_helper.get_dispatched_events('foo')
         self.assertEqual(event['event_type'], 'nack')
+
+
+class TestPublishStatusConnector(BaseConnectorTestCase):
+
+    connector_class = PublishStatusConnector
+
+    @inlineCallbacks
+    def test_publish_status(self):
+        conn = yield self.mk_connector(connector_name='foo', setup=True)
+        msg = self.msg_helper.make_status('good')
+        yield conn.publish_status(msg)
+        msgs = self.worker_helper.get_dispatched_statuses('foo')
+        self.assertEqual(msgs, [msg])
+
+
+class TestReceiveStatusConnector(BaseConnectorTestCase):
+
+    connector_class = ReceiveStatusConnector
+
+    @inlineCallbacks
+    def test_default_status_handler(self):
+        conn = yield self.mk_connector(connector_name='foo', setup=True)
+        with LogCatcher() as lc:
+            conn.default_status_handler(
+                self.msg_helper.make_status('good'))
+            [log] = lc.messages()
+            self.assertTrue(
+                log.startswith("No status handler for 'foo'"))
+
+    @inlineCallbacks
+    def test_set_status_handler(self):
+        msgs = []
+        conn = yield self.mk_connector(connector_name='foo', setup=True)
+        conn.unpause()
+        conn.set_status_handler(msgs.append)
+        msg = self.msg_helper.make_status('good')
+        yield self.worker_helper.dispatch_status(msg, 'foo')
+        self.assertEqual(msgs, [msg])
+
+    @inlineCallbacks
+    def test_set_default_status_handler(self):
+        msgs = []
+        conn = yield self.mk_connector(connector_name='foo', setup=True)
+        conn.unpause()
+        conn.set_default_status_handler(msgs.append)
+        msg = self.msg_helper.make_status('good')
+        yield self.worker_helper.dispatch_status(msg, 'foo')
+        self.assertEqual(msgs, [msg])

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -424,13 +424,3 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
         msg = self.msg_helper.make_status('good')
         yield self.worker_helper.dispatch_status(msg, 'foo')
         self.assertEqual(msgs, [msg])
-
-    @inlineCallbacks
-    def test_set_default_status_handler(self):
-        msgs = []
-        conn = yield self.mk_connector(connector_name='foo', setup=True)
-        conn.unpause()
-        conn.set_default_status_handler(msgs.append)
-        msg = self.msg_helper.make_status('good')
-        yield self.worker_helper.dispatch_status(msg, 'foo')
-        self.assertEqual(msgs, [msg])

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -4,6 +4,7 @@ import json
 from vumi.tests.utils import RegexMatcher, UTCNearNow
 from vumi.message import (
     Message, TransportMessage, TransportEvent, TransportUserMessage,
+    TransportStatus, MissingMessageField, InvalidMessageField,
     format_vumi_date, parse_vumi_date, from_json, to_json)
 from vumi.tests.helpers import VumiTestCase
 
@@ -470,3 +471,21 @@ class TransportEventTest(TransportMessageTestMixin, VumiTestCase):
         # self.assertEqual('sphex', msg['transport_name'])
         self.assertEqual('delivered', msg['delivery_status'])
         self.assertEqual({}, msg['helper_metadata'])
+
+
+class TestTransportStatus(VumiTestCase):
+    def test_defaults(self):
+        msg = TransportStatus(status='good')
+        self.assertEqual(msg['reasons'], [])
+        self.assertEqual(msg['details'], {})
+
+    def test_validate_status_present(self):
+        self.assertRaises(MissingMessageField, TransportStatus)
+
+    def test_validate_status_field(self):
+        TransportStatus(status='good')
+        TransportStatus(status='minor')
+        TransportStatus(status='major')
+
+        self.assertRaises(
+            InvalidMessageField, TransportStatus, status='amazing')

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -1336,7 +1336,7 @@ class TestWorkerHelper(VumiTestCase):
     @inlineCallbacks
     def test_dispatch_status(self):
         """
-        WorkerHelper.dispatch_status() should dispatch an status message.
+        WorkerHelper.dispatch_status() should dispatch a status message.
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
@@ -1670,7 +1670,7 @@ class TestMessageDispatchHelper(VumiTestCase):
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
         broker.exchange_declare('vumi', 'direct')
-        self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
+        self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
         msg = yield md_helper.make_dispatch_status(
             'major', reasons=['too many lemons'])
         self.assertEqual(

--- a/vumi/tests/test_worker.py
+++ b/vumi/tests/test_worker.py
@@ -1,7 +1,9 @@
 from twisted.internet.defer import inlineCallbacks, succeed, Deferred
 
 from vumi.worker import BaseConfig, BaseWorker
-from vumi.connectors import ReceiveInboundConnector, ReceiveOutboundConnector
+from vumi.connectors import (
+    ReceiveInboundConnector, ReceiveOutboundConnector,
+    PublishStatusConnector, ReceiveStatusConnector)
 from vumi.tests.utils import LogCatcher
 from vumi.middleware.base import BaseMiddleware
 from vumi.tests.helpers import VumiTestCase, MessageHelper, WorkerHelper
@@ -192,6 +194,18 @@ class TestBaseWorker(VumiTestCase):
     def test_setup_ro_connector(self):
         connector = yield self.worker.setup_ro_connector('foo')
         self.assertTrue(isinstance(connector, ReceiveOutboundConnector))
+        self.assertEqual(connector.name, 'foo')
+
+    @inlineCallbacks
+    def test_setup_publish_status_connector(self):
+        connector = yield self.worker.setup_publish_status_connector('foo')
+        self.assertTrue(isinstance(connector, PublishStatusConnector))
+        self.assertEqual(connector.name, 'foo')
+
+    @inlineCallbacks
+    def test_setup_receive_status_connector(self):
+        connector = yield self.worker.setup_receive_status_connector('foo')
+        self.assertTrue(isinstance(connector, ReceiveStatusConnector))
         self.assertEqual(connector.name, 'foo')
 
     @inlineCallbacks

--- a/vumi/worker.py
+++ b/vumi/worker.py
@@ -12,7 +12,9 @@ from twisted.python import log
 
 from vumi.service import Worker
 from vumi.middleware import setup_middlewares_from_config
-from vumi.connectors import ReceiveInboundConnector, ReceiveOutboundConnector
+from vumi.connectors import (
+    ReceiveInboundConnector, ReceiveOutboundConnector,
+    PublishStatusConnector, ReceiveStatusConnector)
 from vumi.config import Config, ConfigInt
 from vumi.errors import DuplicateConnectorError
 from vumi.utils import generate_worker_id
@@ -201,6 +203,14 @@ class BaseWorker(Worker):
 
     def setup_ro_connector(self, connector_name, middleware=True):
         return self.setup_connector(ReceiveOutboundConnector, connector_name,
+                                    middleware=middleware)
+
+    def setup_publish_status_connector(self, connector_name, middleware=True):
+        return self.setup_connector(PublishStatusConnector, connector_name,
+                                    middleware=middleware)
+
+    def setup_receive_status_connector(self, connector_name, middleware=True):
+        return self.setup_connector(ReceiveStatusConnector, connector_name,
                                     middleware=middleware)
 
     def pause_connectors(self):


### PR DESCRIPTION
We need a way of publishing and consuming status event messages in workers.

The plan is to add two new connector types, one for publishing status event messages and one for consuming status event messages.