### PR TITLE
Rename 'unbound' status event to 'binding' for SMPP

### DIFF
--- a/vumi/transports/smpp/protocol.py
+++ b/vumi/transports/smpp/protocol.py
@@ -93,7 +93,7 @@ class EsmeProtocol(Protocol):
             system_type=self.config.system_type,
             interface_version=self.config.interface_version,
             address_range=self.config.address_range)
-        yield self.service.on_connection()
+        yield self.service.on_smpp_binding()
 
     @inlineCallbacks
     def bind(self,

--- a/vumi/transports/smpp/smpp_service.py
+++ b/vumi/transports/smpp/smpp_service.py
@@ -198,8 +198,8 @@ class SmppService(ReconnectingClientService):
         yield self.transport.on_smpp_bind()
 
     @inlineCallbacks
-    def on_connection(self):
-        yield self.transport.on_connection()
+    def on_smpp_binding(self):
+        yield self.transport.on_smpp_binding()
 
     @inlineCallbacks
     def on_smpp_bind_timeout(self):

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -299,8 +299,8 @@ class SmppTransceiverTransport(Transport):
             message['message_id'], u'Invalid %s: %s' % (field, message[field]))
 
     @inlineCallbacks
-    def on_connection(self):
-        yield self.publish_status_unbound()
+    def on_smpp_binding(self):
+        yield self.publish_status_binding()
 
     @inlineCallbacks
     def on_smpp_bind(self):
@@ -329,12 +329,12 @@ class SmppTransceiverTransport(Transport):
     def on_connection_lost(self, reason):
         yield self.publish_status_connection_lost(reason)
 
-    def publish_status_unbound(self):
+    def publish_status_binding(self):
         return self.publish_status(
             status='major',
             component='smpp',
-            type='unbound',
-            message='Connected but not bound')
+            type='binding',
+            message='Binding')
 
     def publish_status_bound(self):
         return self.publish_status(

--- a/vumi/transports/smpp/tests/test_protocol.py
+++ b/vumi/transports/smpp/tests/test_protocol.py
@@ -39,11 +39,11 @@ class DummySmppService(object):
     def get_config(self):
         return self._static_config
 
-    def on_connection(self):
-        pass
-
     def on_connection_lost(self, reason):
         self.paused = True
+
+    def on_smpp_binding(self):
+        pass
 
     def on_smpp_bind(self):
         self.paused = False

--- a/vumi/transports/smpp/tests/test_smpp_service.py
+++ b/vumi/transports/smpp/tests/test_smpp_service.py
@@ -45,7 +45,7 @@ class DummySmppTransport(object):
     def unpause_connectors(self):
         self.paused = False
 
-    def on_connection(self):
+    def on_smpp_binding(self):
         pass
 
     def on_smpp_bind(self):

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1678,8 +1678,8 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         [msg] = self.tx_helper.get_dispatched_statuses()
         self.assertEqual(msg['status'], 'major')
         self.assertEqual(msg['component'], 'smpp')
-        self.assertEqual(msg['type'], 'unbound')
-        self.assertEqual(msg['message'], 'Connected but not bound')
+        self.assertEqual(msg['type'], 'binding')
+        self.assertEqual(msg['message'], 'Binding')
 
     @inlineCallbacks
     def test_bind_status(self):
@@ -1799,7 +1799,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         [msg1, msg2, msg3] = self.tx_helper.get_dispatched_statuses()
 
-        self.assertEqual(msg1['type'], 'unbound')
+        self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
         self.assertEqual(msg3['status'], 'minor')
@@ -1859,7 +1859,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         [msg1, msg2, msg3] = self.tx_helper.get_dispatched_statuses()
 
-        self.assertEqual(msg1['type'], 'unbound')
+        self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
         self.assertEqual(msg3['status'], 'minor')


### PR DESCRIPTION
`unbound` doesn't imply we are attempting to bind, `binding` does.