### PR TITLE
Don't remove remote message ids for SMPP delivery reports

### DIFF
--- a/vumi/transports/smpp/config.py
+++ b/vumi/transports/smpp/config.py
@@ -37,6 +37,10 @@ class SmppTransportConfig(Transport.CONFIG_CLASS):
         'for matching submit_sm_resp and delivery report messages. Defaults '
         'to 1 week.',
         default=(60 * 60 * 24 * 7), static=True)
+    final_dr_third_party_id_expiry = ConfigInt(
+        'How long (in seconds) to keep 3rd party message IDs around after '
+        'receiving a success or failure delivery report for the message.',
+        default=(60 * 60), static=True)
     completed_multipart_info_expiry = ConfigInt(
         'How long (in seconds) to keep multipart message info for completed '
         'multipart messages around to avoid pending operations accidentally '

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -240,6 +240,11 @@ class SmppMessageDataStash(object):
         key = remote_message_key(smpp_message_id)
         return self.redis.delete(key)
 
+    def expire_remote_message_id(self, smpp_message_id):
+        key = remote_message_key(smpp_message_id)
+        expire = self.config.final_dr_third_party_id_expiry
+        return self.redis.expire(key, expire)
+
 
 class SmppTransceiverTransport(Transport):
 
@@ -481,7 +486,7 @@ class SmppTransceiverTransport(Transport):
             delivery_status=delivery_status)
 
         if delivery_status in ('delivered', 'failed'):
-            yield self.message_stash.delete_remote_message_id(
+            yield self.message_stash.expire_remote_message_id(
                 receipted_message_id)
 
         returnValue(dr)

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1523,7 +1523,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         self.assertTrue(
             remote_id_ttl > 23,
-            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            "remote_id_ttl (%s) <= final_dr_third_party_id_expiry (23)"
             % (remote_id_ttl,))
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
@@ -1552,7 +1552,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         self.assertTrue(
             remote_id_ttl > 23,
-            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            "remote_id_ttl (%s) <= final_dr_third_party_id_expiry (23)"
             % (remote_id_ttl,))
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
@@ -1581,7 +1581,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         self.assertTrue(
             remote_id_ttl > 23,
-            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            "remote_id_ttl (%s) <= final_dr_third_party_id_expiry (23)"
             % (remote_id_ttl,))
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1519,9 +1519,12 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         })
 
         yield transport.message_stash.set_remote_message_id('bar', 'foo')
+        remote_id_ttl = yield transport.redis.ttl(remote_message_key('foo'))
 
-        self.assertNotEqual(
-            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
+        self.assertTrue(
+            remote_id_ttl > 23,
+            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            % (remote_id_ttl,))
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
         pdu.add_optional_parameter('receipted_message_id', 'foo')
@@ -1530,8 +1533,12 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield self.tx_helper.wait_for_dispatched_events(1)
 
-        self.assertEqual(
-            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
+        remote_id_ttl = yield transport.redis.ttl(remote_message_key('foo'))
+
+        self.assertTrue(
+            remote_id_ttl <= 23,
+            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            % (remote_id_ttl,))
 
     @inlineCallbacks
     def test_delivery_report_failed_delete_stored_remote_id(self):
@@ -1541,8 +1548,12 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield transport.message_stash.set_remote_message_id('bar', 'foo')
 
-        self.assertNotEqual(
-            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
+        remote_id_ttl = yield transport.redis.ttl(remote_message_key('foo'))
+
+        self.assertTrue(
+            remote_id_ttl > 23,
+            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            % (remote_id_ttl,))
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
         pdu.add_optional_parameter('receipted_message_id', 'foo')
@@ -1551,8 +1562,12 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield self.tx_helper.wait_for_dispatched_events(1)
 
-        self.assertEqual(
-            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
+        remote_id_ttl = yield transport.redis.ttl(remote_message_key('foo'))
+
+        self.assertTrue(
+            remote_id_ttl <= 23,
+            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            % (remote_id_ttl,))
 
     @inlineCallbacks
     def test_delivery_report_pending_keep_stored_remote_id(self):
@@ -1562,8 +1577,12 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield transport.message_stash.set_remote_message_id('bar', 'foo')
 
-        self.assertNotEqual(
-            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
+        remote_id_ttl = yield transport.redis.ttl(remote_message_key('foo'))
+
+        self.assertTrue(
+            remote_id_ttl > 23,
+            "remote_id_ttl (%s) > final_dr_third_party_id_expiry (23)"
+            % (remote_id_ttl,))
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
         pdu.add_optional_parameter('receipted_message_id', 'foo')
@@ -1572,8 +1591,12 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield self.tx_helper.wait_for_dispatched_events(1)
 
-        self.assertNotEqual(
-            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
+        remote_id_ttl = yield transport.redis.ttl(remote_message_key('foo'))
+
+        self.assertTrue(
+            remote_id_ttl > 23,
+            "remote_id_ttl (%s) <= final_dr_third_party_id_expiry (23)"
+            % (remote_id_ttl,))
 
     @inlineCallbacks
     def test_reconnect(self):

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1514,8 +1514,14 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
     @inlineCallbacks
     def test_delivery_report_delivered_delete_stored_remote_id(self):
-        transport = yield self.get_transport()
+        transport = yield self.get_transport({
+            'final_dr_third_party_id_expiry': 23,
+        })
+
         yield transport.message_stash.set_remote_message_id('bar', 'foo')
+
+        self.assertNotEqual(
+            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
         pdu.add_optional_parameter('receipted_message_id', 'foo')
@@ -1524,13 +1530,19 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield self.tx_helper.wait_for_dispatched_events(1)
 
-        self.assertFalse(
-            (yield transport.redis.exists(remote_message_key('foo'))))
+        self.assertEqual(
+            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
 
     @inlineCallbacks
     def test_delivery_report_failed_delete_stored_remote_id(self):
-        transport = yield self.get_transport()
+        transport = yield self.get_transport({
+            'final_dr_third_party_id_expiry': 23,
+        })
+
         yield transport.message_stash.set_remote_message_id('bar', 'foo')
+
+        self.assertNotEqual(
+            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
         pdu.add_optional_parameter('receipted_message_id', 'foo')
@@ -1539,13 +1551,19 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield self.tx_helper.wait_for_dispatched_events(1)
 
-        self.assertFalse(
-            (yield transport.redis.exists(remote_message_key('foo'))))
+        self.assertEqual(
+            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
 
     @inlineCallbacks
     def test_delivery_report_pending_keep_stored_remote_id(self):
-        transport = yield self.get_transport()
+        transport = yield self.get_transport({
+            'final_dr_third_party_id_expiry': 23,
+        })
+
         yield transport.message_stash.set_remote_message_id('bar', 'foo')
+
+        self.assertNotEqual(
+            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
 
         pdu = DeliverSM(sequence_number=1, esm_class=4)
         pdu.add_optional_parameter('receipted_message_id', 'foo')
@@ -1554,8 +1572,8 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
 
         yield self.tx_helper.wait_for_dispatched_events(1)
 
-        self.assertTrue(
-            (yield transport.redis.exists(remote_message_key('foo'))))
+        self.assertNotEqual(
+            (yield transport.redis.ttl(remote_message_key('foo'))), 23)
 
     @inlineCallbacks
     def test_reconnect(self):


### PR DESCRIPTION
Since #977 and #978, we remove message ids for failure and success delivery reports. It is common for us to get multiple delivery reports for the same message though, so we can't really do this.