### PR TITLE
Publish status event when starting for SMPP transport

### DIFF
--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -333,7 +333,7 @@ class SmppTransceiverTransport(Transport):
 
     def publish_status_starting(self):
         return self.publish_status(
-            status='major',
+            status='down',
             component='smpp',
             type='starting',
             message='Starting')

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -255,6 +255,8 @@ class SmppTransceiverTransport(Transport):
 
     @inlineCallbacks
     def setup_transport(self):
+        yield self.publish_status_starting()
+
         config = self.get_static_config()
         log.msg('Starting SMPP Transport for: %s' % (config.twisted_endpoint,))
 
@@ -328,6 +330,13 @@ class SmppTransceiverTransport(Transport):
     @inlineCallbacks
     def on_connection_lost(self, reason):
         yield self.publish_status_connection_lost(reason)
+
+    def publish_status_starting(self):
+        return self.publish_status(
+            status='major',
+            component='smpp',
+            type='starting',
+            message='Starting')
 
     def publish_status_binding(self):
         return self.publish_status(

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1666,7 +1666,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
     def test_starting_status(self):
         yield self.get_transport({'publish_status': True})
         [msg] = self.tx_helper.get_dispatched_statuses()[:1]
-        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'starting')
         self.assertEqual(msg['message'], 'Starting')

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1663,6 +1663,15 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(short_message(submit_sm2), 'hello world 1')
 
     @inlineCallbacks
+    def test_starting_status(self):
+        yield self.get_transport({'publish_status': True})
+        [msg] = self.tx_helper.get_dispatched_statuses()[:1]
+        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['component'], 'smpp')
+        self.assertEqual(msg['type'], 'starting')
+        self.assertEqual(msg['message'], 'Starting')
+
+    @inlineCallbacks
     def test_connect_status(self):
         transport = yield self.get_transport(
             {'publish_status': True}, bind=False)


### PR DESCRIPTION
Similar to #983-#988, except for when we start connecting.