### PR TITLE
Rename status event level names

### DIFF
--- a/vumi/message.py
+++ b/vumi/message.py
@@ -435,7 +435,11 @@ class TransportStatus(TransportMessage):
     """Message about a status event emitted by a transport.
     """
     MESSAGE_TYPE = 'status_event'
-    STATUSES = frozenset(('ok', 'degraded', 'down'))
+
+    STATUS_OK = 'ok'
+    STATUS_DEGRADED = 'degraded'
+    STATUS_DOWN = 'down'
+    STATUSES = frozenset((STATUS_OK, STATUS_DEGRADED, STATUS_DOWN))
 
     def process_fields(self, fields):
         super(TransportStatus, self).process_fields(fields)

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -435,11 +435,7 @@ class TransportStatus(TransportMessage):
     """Message about a status event emitted by a transport.
     """
     MESSAGE_TYPE = 'status_event'
-
-    STATUS_OK = 'ok'
-    STATUS_DEGRADED = 'degraded'
-    STATUS_DOWN = 'down'
-    STATUSES = frozenset((STATUS_OK, STATUS_DEGRADED, STATUS_DOWN))
+    STATUSES = frozenset(('ok', 'degraded', 'down'))
 
     def process_fields(self, fields):
         super(TransportStatus, self).process_fields(fields)

--- a/vumi/message.py
+++ b/vumi/message.py
@@ -435,7 +435,7 @@ class TransportStatus(TransportMessage):
     """Message about a status event emitted by a transport.
     """
     MESSAGE_TYPE = 'status_event'
-    STATUSES = frozenset(('good', 'minor', 'major'))
+    STATUSES = frozenset(('ok', 'degraded', 'down'))
 
     def process_fields(self, fields):
         super(TransportStatus, self).process_fields(fields)

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -5,7 +5,7 @@ from vumi.connectors import (
     PublishStatusConnector, ReceiveStatusConnector, IgnoreMessage)
 from vumi.tests.utils import LogCatcher
 from vumi.worker import BaseWorker
-from vumi.message import TransportUserMessage
+from vumi.message import TransportUserMessage, TransportStatus
 from vumi.middleware.tests.utils import RecordingMiddleware
 from vumi.tests.helpers import VumiTestCase, MessageHelper, WorkerHelper
 

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -5,7 +5,7 @@ from vumi.connectors import (
     PublishStatusConnector, ReceiveStatusConnector, IgnoreMessage)
 from vumi.tests.utils import LogCatcher
 from vumi.worker import BaseWorker
-from vumi.message import TransportUserMessage, TransportStatus
+from vumi.message import TransportUserMessage
 from vumi.middleware.tests.utils import RecordingMiddleware
 from vumi.tests.helpers import VumiTestCase, MessageHelper, WorkerHelper
 
@@ -397,7 +397,7 @@ class TestPublishStatusConnector(BaseConnectorTestCase):
         conn = yield self.mk_connector(connector_name='foo', setup=True)
 
         msg = self.msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -415,7 +415,7 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
     def test_default_status_handler(self):
         conn = yield self.mk_connector(connector_name='foo', setup=True)
         msg = self.msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -435,7 +435,7 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
         conn.set_status_handler(msgs.append)
 
         msg = self.msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -397,7 +397,7 @@ class TestPublishStatusConnector(BaseConnectorTestCase):
         conn = yield self.mk_connector(connector_name='foo', setup=True)
 
         msg = self.msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -415,7 +415,7 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
     def test_default_status_handler(self):
         conn = yield self.mk_connector(connector_name='foo', setup=True)
         msg = self.msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -435,7 +435,7 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
         conn.set_status_handler(msgs.append)
 
         msg = self.msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -397,7 +397,7 @@ class TestPublishStatusConnector(BaseConnectorTestCase):
         conn = yield self.mk_connector(connector_name='foo', setup=True)
 
         msg = self.msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -415,7 +415,7 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
     def test_default_status_handler(self):
         conn = yield self.mk_connector(connector_name='foo', setup=True)
         msg = self.msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -435,7 +435,7 @@ class TestReceiveStatusConnector(BaseConnectorTestCase):
         conn.set_status_handler(msgs.append)
 
         msg = self.msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -477,7 +477,7 @@ class TestTransportStatus(VumiTestCase):
     def test_defaults(self):
         msg = TransportStatus(
             component='foo',
-            status=TransportStatus.STATUS_OK,
+            status='ok',
             type='bar',
             message='baz')
 
@@ -486,7 +486,7 @@ class TestTransportStatus(VumiTestCase):
     def test_validate_component_present(self):
         self.assertRaises(
             MissingMessageField, TransportStatus,
-            status=TransportStatus.STATUS_OK, type='bar', message='baz')
+            status='ok', type='bar', message='baz')
 
     def test_validate_status_present(self):
         self.assertRaises(
@@ -495,19 +495,19 @@ class TestTransportStatus(VumiTestCase):
 
     def test_validate_status_field(self):
         TransportStatus(
-            status=TransportStatus.STATUS_OK,
+            status='ok',
             component='foo',
             type='bar',
             message='baz')
 
         TransportStatus(
-            status=TransportStatus.STATUS_DEGRADED,
+            status='degraded',
             component='foo',
             type='bar',
             message='baz')
 
         TransportStatus(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -477,7 +477,7 @@ class TestTransportStatus(VumiTestCase):
     def test_defaults(self):
         msg = TransportStatus(
             component='foo',
-            status='good',
+            status='ok',
             type='bar',
             message='baz')
 
@@ -486,7 +486,7 @@ class TestTransportStatus(VumiTestCase):
     def test_validate_component_present(self):
         self.assertRaises(
             MissingMessageField, TransportStatus,
-            status='good', type='bar', message='baz')
+            status='ok', type='bar', message='baz')
 
     def test_validate_status_present(self):
         self.assertRaises(
@@ -495,19 +495,19 @@ class TestTransportStatus(VumiTestCase):
 
     def test_validate_status_field(self):
         TransportStatus(
-            status='good',
+            status='ok',
             component='foo',
             type='bar',
             message='baz')
 
         TransportStatus(
-            status='minor',
+            status='degraded',
             component='foo',
             type='bar',
             message='baz')
 
         TransportStatus(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -477,7 +477,7 @@ class TestTransportStatus(VumiTestCase):
     def test_defaults(self):
         msg = TransportStatus(
             component='foo',
-            status='ok',
+            status=TransportStatus.STATUS_OK,
             type='bar',
             message='baz')
 
@@ -486,7 +486,7 @@ class TestTransportStatus(VumiTestCase):
     def test_validate_component_present(self):
         self.assertRaises(
             MissingMessageField, TransportStatus,
-            status='ok', type='bar', message='baz')
+            status=TransportStatus.STATUS_OK, type='bar', message='baz')
 
     def test_validate_status_present(self):
         self.assertRaises(
@@ -495,19 +495,19 @@ class TestTransportStatus(VumiTestCase):
 
     def test_validate_status_field(self):
         TransportStatus(
-            status='ok',
+            status=TransportStatus.STATUS_OK,
             component='foo',
             type='bar',
             message='baz')
 
         TransportStatus(
-            status='degraded',
+            status=TransportStatus.STATUS_DEGRADED,
             component='foo',
             type='bar',
             message='baz')
 
         TransportStatus(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -593,7 +593,7 @@ class TestMessageHelper(TestCase):
         """
         msg_helper = MessageHelper()
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -601,7 +601,7 @@ class TestMessageHelper(TestCase):
         self.assertIsInstance(msg, TransportStatus)
 
         self.assert_message_fields(msg, {
-            'status': 'major',
+            'status': 'down',
             'component': 'foo',
             'type': 'bar',
             'message': 'baz',
@@ -956,7 +956,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [])
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -977,7 +977,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [])
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1090,7 +1090,7 @@ class TestWorkerHelper(VumiTestCase):
         d = worker_helper.wait_for_dispatched_statuses(1, 'fooconn')
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1111,7 +1111,7 @@ class TestWorkerHelper(VumiTestCase):
         d = worker_helper.wait_for_dispatched_statuses(1)
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1226,7 +1226,7 @@ class TestWorkerHelper(VumiTestCase):
         worker_helper = WorkerHelper()
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1250,7 +1250,7 @@ class TestWorkerHelper(VumiTestCase):
         worker_helper = WorkerHelper(status_connector_name='fooconn')
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1396,7 +1396,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1420,7 +1420,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = msg_helper.make_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1739,7 +1739,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = yield md_helper.make_dispatch_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1748,7 +1748,7 @@ class TestMessageDispatchHelper(VumiTestCase):
             broker.get_messages('vumi', 'fooconn.status'), [msg])
 
         self.assert_message_fields(msg, {
-            'status': 'major',
+            'status': 'down',
             'component': 'foo',
             'type': 'bar',
             'message': 'baz',

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -593,7 +593,7 @@ class TestMessageHelper(TestCase):
         """
         msg_helper = MessageHelper()
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -601,7 +601,7 @@ class TestMessageHelper(TestCase):
         self.assertIsInstance(msg, TransportStatus)
 
         self.assert_message_fields(msg, {
-            'status': 'down',
+            'status': TransportStatus.STATUS_DOWN,
             'component': 'foo',
             'type': 'bar',
             'message': 'baz',
@@ -956,7 +956,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [])
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -977,7 +977,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [])
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1090,7 +1090,7 @@ class TestWorkerHelper(VumiTestCase):
         d = worker_helper.wait_for_dispatched_statuses(1, 'fooconn')
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1111,7 +1111,7 @@ class TestWorkerHelper(VumiTestCase):
         d = worker_helper.wait_for_dispatched_statuses(1)
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1226,7 +1226,7 @@ class TestWorkerHelper(VumiTestCase):
         worker_helper = WorkerHelper()
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1250,7 +1250,7 @@ class TestWorkerHelper(VumiTestCase):
         worker_helper = WorkerHelper(status_connector_name='fooconn')
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1396,7 +1396,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1420,7 +1420,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = msg_helper.make_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1739,7 +1739,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = yield md_helper.make_dispatch_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='foo',
             type='bar',
             message='baz')
@@ -1748,7 +1748,7 @@ class TestMessageDispatchHelper(VumiTestCase):
             broker.get_messages('vumi', 'fooconn.status'), [msg])
 
         self.assert_message_fields(msg, {
-            'status': 'down',
+            'status': TransportStatus.STATUS_DOWN,
             'component': 'foo',
             'type': 'bar',
             'message': 'baz',

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -593,7 +593,7 @@ class TestMessageHelper(TestCase):
         """
         msg_helper = MessageHelper()
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -601,7 +601,7 @@ class TestMessageHelper(TestCase):
         self.assertIsInstance(msg, TransportStatus)
 
         self.assert_message_fields(msg, {
-            'status': TransportStatus.STATUS_DOWN,
+            'status': 'down',
             'component': 'foo',
             'type': 'bar',
             'message': 'baz',
@@ -956,7 +956,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [])
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -977,7 +977,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [])
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1090,7 +1090,7 @@ class TestWorkerHelper(VumiTestCase):
         d = worker_helper.wait_for_dispatched_statuses(1, 'fooconn')
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1111,7 +1111,7 @@ class TestWorkerHelper(VumiTestCase):
         d = worker_helper.wait_for_dispatched_statuses(1)
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1226,7 +1226,7 @@ class TestWorkerHelper(VumiTestCase):
         worker_helper = WorkerHelper()
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1250,7 +1250,7 @@ class TestWorkerHelper(VumiTestCase):
         worker_helper = WorkerHelper(status_connector_name='fooconn')
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1396,7 +1396,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1420,7 +1420,7 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = msg_helper.make_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1739,7 +1739,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = yield md_helper.make_dispatch_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='foo',
             type='bar',
             message='baz')
@@ -1748,7 +1748,7 @@ class TestMessageDispatchHelper(VumiTestCase):
             broker.get_messages('vumi', 'fooconn.status'), [msg])
 
         self.assert_message_fields(msg, {
-            'status': TransportStatus.STATUS_DOWN,
+            'status': 'down',
             'component': 'foo',
             'type': 'bar',
             'message': 'baz',

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -10,7 +10,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue, succeed
 from smpp.pdu import decode_pdu
 from smpp.pdu_builder import PDU
 from vumi import log
-from vumi.message import TransportUserMessage
+from vumi.message import TransportUserMessage, TransportStatus
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.transports.base import Transport
 from vumi.transports.smpp.config import SmppTransportConfig
@@ -331,42 +331,42 @@ class SmppTransceiverTransport(Transport):
 
     def publish_status_binding(self):
         return self.publish_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='smpp',
             type='binding',
             message='Binding')
 
     def publish_status_bound(self):
         return self.publish_status(
-            status='ok',
+            status=TransportStatus.STATUS_OK,
             component='smpp',
             type='bound',
             message='Bound')
 
     def publish_throttled(self):
         return self.publish_status(
-            status='degraded',
+            status=TransportStatus.STATUS_DEGRADED,
             component='smpp',
             type='throttled',
             message='Throttled')
 
     def publish_throttled_end(self):
         return self.publish_status(
-            status='ok',
+            status=TransportStatus.STATUS_OK,
             component='smpp',
             type='throttled_end',
             message='No longer throttled')
 
     def publish_status_bind_timeout(self):
         return self.publish_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='smpp',
             type='bind_timeout',
             message='Timed out awaiting bind')
 
     def publish_status_connection_lost(self, reason):
         return self.publish_status(
-            status='down',
+            status=TransportStatus.STATUS_DOWN,
             component='smpp',
             type='connection_lost',
             message=str(reason.value))

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -10,7 +10,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue, succeed
 from smpp.pdu import decode_pdu
 from smpp.pdu_builder import PDU
 from vumi import log
-from vumi.message import TransportUserMessage, TransportStatus
+from vumi.message import TransportUserMessage
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.transports.base import Transport
 from vumi.transports.smpp.config import SmppTransportConfig
@@ -331,42 +331,42 @@ class SmppTransceiverTransport(Transport):
 
     def publish_status_binding(self):
         return self.publish_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='smpp',
             type='binding',
             message='Binding')
 
     def publish_status_bound(self):
         return self.publish_status(
-            status=TransportStatus.STATUS_OK,
+            status='ok',
             component='smpp',
             type='bound',
             message='Bound')
 
     def publish_throttled(self):
         return self.publish_status(
-            status=TransportStatus.STATUS_DEGRADED,
+            status='degraded',
             component='smpp',
             type='throttled',
             message='Throttled')
 
     def publish_throttled_end(self):
         return self.publish_status(
-            status=TransportStatus.STATUS_OK,
+            status='ok',
             component='smpp',
             type='throttled_end',
             message='No longer throttled')
 
     def publish_status_bind_timeout(self):
         return self.publish_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='smpp',
             type='bind_timeout',
             message='Timed out awaiting bind')
 
     def publish_status_connection_lost(self, reason):
         return self.publish_status(
-            status=TransportStatus.STATUS_DOWN,
+            status='down',
             component='smpp',
             type='connection_lost',
             message=str(reason.value))

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -331,42 +331,42 @@ class SmppTransceiverTransport(Transport):
 
     def publish_status_binding(self):
         return self.publish_status(
-            status='major',
+            status='down',
             component='smpp',
             type='binding',
             message='Binding')
 
     def publish_status_bound(self):
         return self.publish_status(
-            status='good',
+            status='ok',
             component='smpp',
             type='bound',
             message='Bound')
 
     def publish_throttled(self):
         return self.publish_status(
-            status='minor',
+            status='degraded',
             component='smpp',
             type='throttled',
             message='Throttled')
 
     def publish_throttled_end(self):
         return self.publish_status(
-            status='good',
+            status='ok',
             component='smpp',
             type='throttled_end',
             message='No longer throttled')
 
     def publish_status_bind_timeout(self):
         return self.publish_status(
-            status='major',
+            status='down',
             component='smpp',
             type='bind_timeout',
             message='Timed out awaiting bind')
 
     def publish_status_connection_lost(self, reason):
         return self.publish_status(
-            status='major',
+            status='down',
             component='smpp',
             type='connection_lost',
             message=str(reason.value))

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -1676,7 +1676,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.await_connected()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'binding')
         self.assertEqual(msg['message'], 'Binding')
@@ -1690,7 +1690,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.bind()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'good')
+        self.assertEqual(msg['status'], 'ok')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'bound')
         self.assertEqual(msg['message'], 'Bound')
@@ -1709,7 +1709,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(3)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'bind_timeout')
         self.assertEqual(msg['message'], 'Timed out awaiting bind')
@@ -1724,8 +1724,8 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.disconnect()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'major')
-        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['status'], 'down')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'connection_lost')
 
@@ -1752,7 +1752,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
                          command_status='ESME_RTHROTTLED'))
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'minor')
+        self.assertEqual(msg['status'], 'degraded')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled')
         self.assertEqual(msg['message'], 'Throttled')
@@ -1769,7 +1769,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(0)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'good')
+        self.assertEqual(msg['status'], 'ok')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled_end')
         self.assertEqual(msg['message'], 'No longer throttled')
@@ -1802,7 +1802,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
-        self.assertEqual(msg3['status'], 'minor')
+        self.assertEqual(msg3['status'], 'degraded')
         self.assertEqual(msg3['component'], 'smpp')
         self.assertEqual(msg3['type'], 'throttled')
         self.assertEqual(msg3['message'], 'Throttled')
@@ -1822,7 +1822,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.await_pdus(2)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'minor')
+        self.assertEqual(msg['status'], 'degraded')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled')
         self.assertEqual(msg['message'], 'Throttled')
@@ -1832,7 +1832,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(1)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'good')
+        self.assertEqual(msg['status'], 'ok')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled_end')
         self.assertEqual(msg['message'], 'No longer throttled')
@@ -1862,7 +1862,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
-        self.assertEqual(msg3['status'], 'minor')
+        self.assertEqual(msg3['status'], 'degraded')
         self.assertEqual(msg3['component'], 'smpp')
         self.assertEqual(msg3['type'], 'throttled')
         self.assertEqual(msg3['message'], 'Throttled')

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -7,7 +7,7 @@ from twisted.internet.task import Clock
 
 from smpp.pdu_builder import DeliverSM, SubmitSMResp
 from vumi.config import ConfigError
-from vumi.message import TransportUserMessage, TransportStatus
+from vumi.message import TransportUserMessage
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 from vumi.transports.smpp.smpp_transport import (
@@ -1676,7 +1676,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.await_connected()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'binding')
         self.assertEqual(msg['message'], 'Binding')
@@ -1690,7 +1690,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.bind()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_OK)
+        self.assertEqual(msg['status'], 'ok')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'bound')
         self.assertEqual(msg['message'], 'Bound')
@@ -1709,7 +1709,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(3)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'bind_timeout')
         self.assertEqual(msg['message'], 'Timed out awaiting bind')
@@ -1724,8 +1724,8 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.disconnect()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
-        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
+        self.assertEqual(msg['status'], 'down')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'connection_lost')
 
@@ -1752,7 +1752,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
                          command_status='ESME_RTHROTTLED'))
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_DEGRADED)
+        self.assertEqual(msg['status'], 'degraded')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled')
         self.assertEqual(msg['message'], 'Throttled')
@@ -1769,7 +1769,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(0)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_OK)
+        self.assertEqual(msg['status'], 'ok')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled_end')
         self.assertEqual(msg['message'], 'No longer throttled')
@@ -1802,7 +1802,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
-        self.assertEqual(msg3['status'], TransportStatus.STATUS_DEGRADED)
+        self.assertEqual(msg3['status'], 'degraded')
         self.assertEqual(msg3['component'], 'smpp')
         self.assertEqual(msg3['type'], 'throttled')
         self.assertEqual(msg3['message'], 'Throttled')
@@ -1822,7 +1822,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.await_pdus(2)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_DEGRADED)
+        self.assertEqual(msg['status'], 'degraded')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled')
         self.assertEqual(msg['message'], 'Throttled')
@@ -1832,7 +1832,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(1)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], TransportStatus.STATUS_OK)
+        self.assertEqual(msg['status'], 'ok')
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled_end')
         self.assertEqual(msg['message'], 'No longer throttled')
@@ -1862,7 +1862,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
-        self.assertEqual(msg3['status'], TransportStatus.STATUS_DEGRADED)
+        self.assertEqual(msg3['status'], 'degraded')
         self.assertEqual(msg3['component'], 'smpp')
         self.assertEqual(msg3['type'], 'throttled')
         self.assertEqual(msg3['message'], 'Throttled')

--- a/vumi/transports/smpp/tests/test_smpp_transport.py
+++ b/vumi/transports/smpp/tests/test_smpp_transport.py
@@ -7,7 +7,7 @@ from twisted.internet.task import Clock
 
 from smpp.pdu_builder import DeliverSM, SubmitSMResp
 from vumi.config import ConfigError
-from vumi.message import TransportUserMessage
+from vumi.message import TransportUserMessage, TransportStatus
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 from vumi.transports.smpp.smpp_transport import (
@@ -1676,7 +1676,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.await_connected()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'down')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'binding')
         self.assertEqual(msg['message'], 'Binding')
@@ -1690,7 +1690,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.bind()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'ok')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_OK)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'bound')
         self.assertEqual(msg['message'], 'Bound')
@@ -1709,7 +1709,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(3)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'down')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'bind_timeout')
         self.assertEqual(msg['message'], 'Timed out awaiting bind')
@@ -1724,8 +1724,8 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.disconnect()
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'down')
-        self.assertEqual(msg['status'], 'down')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
+        self.assertEqual(msg['status'], TransportStatus.STATUS_DOWN)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'connection_lost')
 
@@ -1752,7 +1752,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
                          command_status='ESME_RTHROTTLED'))
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'degraded')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_DEGRADED)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled')
         self.assertEqual(msg['message'], 'Throttled')
@@ -1769,7 +1769,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(0)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'ok')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_OK)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled_end')
         self.assertEqual(msg['message'], 'No longer throttled')
@@ -1802,7 +1802,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
-        self.assertEqual(msg3['status'], 'degraded')
+        self.assertEqual(msg3['status'], TransportStatus.STATUS_DEGRADED)
         self.assertEqual(msg3['component'], 'smpp')
         self.assertEqual(msg3['type'], 'throttled')
         self.assertEqual(msg3['message'], 'Throttled')
@@ -1822,7 +1822,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         yield self.fake_smsc.await_pdus(2)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'degraded')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_DEGRADED)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled')
         self.assertEqual(msg['message'], 'Throttled')
@@ -1832,7 +1832,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.clock.advance(1)
 
         [msg] = self.tx_helper.get_dispatched_statuses()
-        self.assertEqual(msg['status'], 'ok')
+        self.assertEqual(msg['status'], TransportStatus.STATUS_OK)
         self.assertEqual(msg['component'], 'smpp')
         self.assertEqual(msg['type'], 'throttled_end')
         self.assertEqual(msg['message'], 'No longer throttled')
@@ -1862,7 +1862,7 @@ class SmppTransceiverTransportTestCase(SmppTransportTestCase):
         self.assertEqual(msg1['type'], 'binding')
         self.assertEqual(msg2['type'], 'bound')
 
-        self.assertEqual(msg3['status'], 'degraded')
+        self.assertEqual(msg3['status'], TransportStatus.STATUS_DEGRADED)
         self.assertEqual(msg3['component'], 'smpp')
         self.assertEqual(msg3['type'], 'throttled')
         self.assertEqual(msg3['message'], 'Throttled')

--- a/vumi/transports/tests/test_base.py
+++ b/vumi/transports/tests/test_base.py
@@ -123,12 +123,12 @@ class TestBaseTransport(VumiTestCase):
         })
 
         msg = yield transport.publish_status(
-            status='major',
+            status='down',
             component='foo',
             type='bar',
             message='baz')
 
-        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'foo')
         self.assertEqual(msg['type'], 'bar')
         self.assertEqual(msg['message'], 'baz')
@@ -145,14 +145,14 @@ class TestBaseTransport(VumiTestCase):
 
         with LogCatcher() as lc:
             msg = yield transport.publish_status(
-                status='major',
+                status='down',
                 component='foo',
                 type='bar',
                 message='baz')
 
             logs = lc.messages()
 
-        self.assertEqual(msg['status'], 'major')
+        self.assertEqual(msg['status'], 'down')
         self.assertEqual(msg['component'], 'foo')
         self.assertEqual(msg['type'], 'bar')
         self.assertEqual(msg['message'], 'baz')


### PR DESCRIPTION
At the moment we use `good`, `minor` and `major`. The plan is to change these to `ok`, `degraded` and `down`, since those are better descriptions for what the status events mean.