### PR TITLE
Ensure type and message fields are present for TransportStatus

### DIFF
--- a/vumi/message.py
+++ b/vumi/message.py
@@ -447,6 +447,8 @@ class TransportStatus(TransportMessage):
         super(TransportStatus, self).validate_fields()
         self.assert_field_present('component')
         self.assert_field_present('status')
+        self.assert_field_present('type')
+        self.assert_field_present('message')
 
         if self.payload['status'] not in self.STATUSES:
             raise InvalidMessageField(

--- a/vumi/tests/test_message.py
+++ b/vumi/tests/test_message.py
@@ -493,6 +493,16 @@ class TestTransportStatus(VumiTestCase):
             MissingMessageField, TransportStatus,
             component='foo', type='bar', message='baz')
 
+    def test_validate_type_present(self):
+        self.assertRaises(
+            MissingMessageField, TransportStatus,
+             status='ok', component='foo', message='baz')
+
+    def test_validate_message_present(self):
+        self.assertRaises(
+            MissingMessageField, TransportStatus,
+             status='ok', component='foo', type='bar')
+
     def test_validate_status_field(self):
         TransportStatus(
             status='ok',


### PR DESCRIPTION
These fields should be mandatory, but we don't ensure they are present when validating a `TransportStatus` message.