### PR TITLE
Fix StreamingClient

### DIFF
--- a/vumi/transports/vumi_bridge/client.py
+++ b/vumi/transports/vumi_bridge/client.py
@@ -87,7 +87,7 @@ class VumiMessageReceiver(basic.LineReceiver):
 
 class StreamingClient(object):
 
-    def __init__(self, agent_factory):
+    def __init__(self, agent_factory=None):
         if agent_factory is None:
             agent_factory = Agent
         self.agent = agent_factory(reactor)

--- a/vumi/transports/vumi_bridge/tests/test_client.py
+++ b/vumi/transports/vumi_bridge/tests/test_client.py
@@ -38,6 +38,7 @@ class TestStreamingClient(VumiTestCase):
         """
         self.assertNotIsInstance(self.client.agent, Agent)
         self.assertIsInstance(StreamingClient(None).agent, Agent)
+        self.assertIsInstance(StreamingClient().agent, Agent)
 
     @inlineCallbacks
     def test_callback_on_disconnect(self):


### PR DESCRIPTION
#974 changed `vumi.transports.vumi_bridge.client.StreamingClient`'s constructor in a way that breaks vumi-go's HTTP API application worker.