### PR TITLE
Separate fake AMQP channel from real AMQP client

### DIFF
--- a/vumi/application/tests/test_base.py
+++ b/vumi/application/tests/test_base.py
@@ -177,7 +177,8 @@ class TestApplicationWorker(VumiTestCase):
             'amqp_prefetch_count': 10,
             })
         for consumer in self.get_app_consumers(app):
-            self.assertEqual(consumer.channel.qos_prefetch_count, 10)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 10)
 
     @inlineCallbacks
     def test_application_prefetch_count_default(self):
@@ -185,7 +186,8 @@ class TestApplicationWorker(VumiTestCase):
             'transport_name': 'test',
             })
         for consumer in self.get_app_consumers(app):
-            self.assertEqual(consumer.channel.qos_prefetch_count, 20)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 20)
 
     @inlineCallbacks
     def test_application_prefetch_count_none(self):
@@ -194,7 +196,8 @@ class TestApplicationWorker(VumiTestCase):
             'amqp_prefetch_count': None,
             })
         for consumer in self.get_app_consumers(app):
-            self.assertFalse(consumer.channel.qos_prefetch_count)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 0)
 
     def assertNotRaises(self, error_class, f, *args, **kw):
         try:

--- a/vumi/dispatchers/tests/test_base.py
+++ b/vumi/dispatchers/tests/test_base.py
@@ -219,21 +219,24 @@ class TestBaseDispatchWorker(VumiTestCase):
         dp = yield self.get_dispatcher()
         consumers = self.get_dispatcher_consumers(dp)
         for consumer in consumers:
-            self.assertEqual(consumer.channel.qos_prefetch_count, 20)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 20)
 
     @inlineCallbacks
     def test_consumer_prefetch_count_custom(self):
         dp = yield self.get_dispatcher(amqp_prefetch_count=10)
         consumers = self.get_dispatcher_consumers(dp)
         for consumer in consumers:
-            self.assertEqual(consumer.channel.qos_prefetch_count, 10)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 10)
 
     @inlineCallbacks
     def test_consumer_prefetch_count_none(self):
         dp = yield self.get_dispatcher(amqp_prefetch_count=None)
         consumers = self.get_dispatcher_consumers(dp)
         for consumer in consumers:
-            self.assertFalse(consumer.channel.qos_prefetch_count)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 0)
 
 
 class TestToAddrRouter(VumiTestCase):

--- a/vumi/dispatchers/tests/test_endpoint_dispatchers.py
+++ b/vumi/dispatchers/tests/test_endpoint_dispatchers.py
@@ -219,18 +219,21 @@ class TestRoutingTableDispatcher(VumiTestCase):
         dp = yield self.get_dispatcher()
         consumers = self.get_dispatcher_consumers(dp)
         for consumer in consumers:
-            self.assertEqual(consumer.channel.qos_prefetch_count, 20)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 20)
 
     @inlineCallbacks
     def test_consumer_prefetch_count_custom(self):
         dp = yield self.get_dispatcher(amqp_prefetch_count=10)
         consumers = self.get_dispatcher_consumers(dp)
         for consumer in consumers:
-            self.assertEqual(consumer.channel.qos_prefetch_count, 10)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 10)
 
     @inlineCallbacks
     def test_consumer_prefetch_count_none(self):
         dp = yield self.get_dispatcher(amqp_prefetch_count=None)
         consumers = self.get_dispatcher_consumers(dp)
         for consumer in consumers:
-            self.assertFalse(consumer.channel.qos_prefetch_count)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 0)

--- a/vumi/service.py
+++ b/vumi/service.py
@@ -259,9 +259,9 @@ class Consumer(object):
 
     def __init__(self, channel):
         self.channel = channel
+        self._fake_channel = getattr(self.channel, '_fake_channel', None)
         self._notify_paused_and_quiet = []
         self.keep_consuming = False
-        self._testing = hasattr(self.channel, 'message_processed')
         self.queue = None
         self._consumer_tag = None
 
@@ -341,8 +341,8 @@ class Consumer(object):
             # broken, but we still decrement the _in_progress counter so we
             # don't wait forever for it during shutdown.
             self._in_progress -= 1
-            if self._testing:
-                self.channel.message_processed()
+            if self._fake_channel is not None:
+                self._fake_channel.message_processed()
         if result is not False:
             yield self.channel.basic_ack(message.delivery_tag, False)
         else:

--- a/vumi/tests/fake_amqp.py
+++ b/vumi/tests/fake_amqp.py
@@ -488,8 +488,61 @@ class FakeAMQClient(WorkerAMQClient):
             try:
                 ch = self.channels[id]
             except KeyError:
-                ch = FakeAMQPChannel(id, self)
+                ch = FakeAMQPChannelWrapper(id, self)
                 self.channels[id] = ch
         finally:
             self.channelLock.release()
         returnValue(ch)
+
+
+class FakeAMQPChannelWrapper(object):
+    def __init__(self, id, client):
+        self._fake_channel = FakeAMQPChannel(id, client)
+        self.client = client
+
+    def __repr__(self):
+        return '<FakeAMQPChannelWrapper: id=%s>' % (
+            self._fake_channel.channel_id,)
+
+    def channel_open(self):
+        return self._fake_channel.channel_open()
+
+    def channel_close(self):
+        return self._fake_channel.channel_close()
+
+    def channel_flow(self, active):
+        return self._fake_channel.channel_flow(active)
+
+    def close(self, _reason):
+        pass
+
+    def basic_qos(self, prefetch_size, prefetch_count, is_global):
+        return self._fake_channel.basic_qos(
+            prefetch_size, prefetch_count, is_global)
+
+    def exchange_declare(self, exchange, type, durable=None):
+        return self._fake_channel.exchange_declare(exchange, type, durable)
+
+    def queue_declare(self, queue, durable=None):
+        return self._fake_channel.queue_declare(queue, durable)
+
+    def queue_bind(self, queue, exchange, routing_key):
+        return self._fake_channel.queue_bind(queue, exchange, routing_key)
+
+    def basic_consume(self, queue, tag=None):
+        return self._fake_channel.basic_consume(queue, tag)
+
+    def basic_cancel(self, tag):
+        return self._fake_channel.basic_cancel(tag)
+
+    def basic_publish(self, exchange, routing_key, content):
+        return self._fake_channel.basic_publish(exchange, routing_key, content)
+
+    def basic_ack(self, delivery_tag, multiple):
+        return self._fake_channel.basic_ack(delivery_tag, multiple)
+
+    def basic_get(self, queue):
+        return self._fake_channel.basic_get(queue)
+
+    def message_processed(self):
+        return self._fake_channel.message_processed()

--- a/vumi/tests/fake_amqp.py
+++ b/vumi/tests/fake_amqp.py
@@ -496,6 +496,11 @@ class FakeAMQClient(WorkerAMQClient):
 
 
 class FakeAMQPChannelWrapper(object):
+    """
+    Wrapper around a FakeAMQPChannel to make it look more like a real channel
+    object.
+    """
+
     def __init__(self, id, client):
         self._fake_channel = FakeAMQPChannel(id, client)
         self.client = client
@@ -543,6 +548,3 @@ class FakeAMQPChannelWrapper(object):
 
     def basic_get(self, queue):
         return self._fake_channel.basic_get(queue)
-
-    def message_processed(self):
-        return self._fake_channel.message_processed()

--- a/vumi/tests/test_connectors.py
+++ b/vumi/tests/test_connectors.py
@@ -97,9 +97,10 @@ class TestBaseConnector(BaseConnectorTestCase):
                           for i in range(2, -1, -1)])
 
     @inlineCallbacks
-    def test_pretech_count(self):
+    def test_prefetch_count(self):
         conn, consumer = yield self.mk_consumer(prefetch_count=10)
-        self.assertEqual(consumer.channel.qos_prefetch_count, 10)
+        fake_channel = consumer.channel._fake_channel
+        self.assertEqual(fake_channel.qos_prefetch_count, 10)
 
     @inlineCallbacks
     def test_setup_raises(self):

--- a/vumi/transports/tests/test_base.py
+++ b/vumi/transports/tests/test_base.py
@@ -94,7 +94,8 @@ class TestBaseTransport(VumiTestCase):
         consumers = list(self.get_tx_consumers(transport))
         self.assertEqual(1, len(consumers))
         for consumer in consumers:
-            self.assertEqual(consumer.channel.qos_prefetch_count, 1)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 1)
 
     @inlineCallbacks
     def test_transport_prefetch_count_default(self):
@@ -102,7 +103,8 @@ class TestBaseTransport(VumiTestCase):
         consumers = list(self.get_tx_consumers(transport))
         self.assertEqual(1, len(consumers))
         for consumer in consumers:
-            self.assertEqual(consumer.channel.qos_prefetch_count, 20)
+            fake_channel = consumer.channel._fake_channel
+            self.assertEqual(fake_channel.qos_prefetch_count, 20)
 
     @inlineCallbacks
     def test_add_outbound_handler(self):


### PR DESCRIPTION
We have a few tests that look for fake AQMP things on the channel objects belonging to clients. As part of the work in #1000, AMQP clients will get real channel objects instead fake ones and will have to look at `channel._fake_channel` to get at the fake stuff.

To make that transition easier, it seems sensible to wrap the current fake channel with a more realistic one and expose the underlying fake on `channel._fake_channel`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/praekelt/vumi/1002)
<!-- Reviewable:end -->
