### PR TITLE
Add a helper method for publishing status events in http rpc transport

### DIFF
--- a/vumi/tests/test_utils.py
+++ b/vumi/tests/test_utils.py
@@ -447,83 +447,83 @@ class TestStatusEdgeDetector(VumiTestCase):
     def test_status_not_change(self):
         '''If the status doesn't change, None should be returned.'''
         sed = StatusEdgeDetector()
-        status1 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='bar',
-            message='test')
-        self.assertEqual(sed.check_status(status1), status1)
+        status1 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'test'}
+        self.assertEqual(sed.check_status(**status1), status1)
 
-        status2 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='bar',
-            message='another test')
-        self.assertEqual(sed.check_status(status2), None)
+        status2 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'another test'}
+        self.assertEqual(sed.check_status(**status2), None)
 
     def test_status_change(self):
         '''If the status does change, the status should be returned.'''
         sed = StatusEdgeDetector()
-        status1 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='bar',
-            message='test')
-        self.assertEqual(sed.check_status(status1), status1)
+        status1 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'test'}
+        self.assertEqual(sed.check_status(**status1), status1)
 
-        status2 = TransportStatus(
-            component='foo',
-            status='degraded',
-            type='bar',
-            message='another test')
-        self.assertEqual(sed.check_status(status2), status2)
+        status2 = {
+            'component': 'foo',
+            'status': 'degraded',
+            'type': 'bar',
+            'message': 'another test'}
+        self.assertEqual(sed.check_status(**status2), status2)
 
     def test_components_separate(self):
         '''A state change in one component should not affect other
         components.'''
         sed = StatusEdgeDetector()
-        comp1_status1 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='bar',
-            message='test')
-        self.assertEqual(sed.check_status(comp1_status1), comp1_status1)
+        comp1_status1 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'test'}
+        self.assertEqual(sed.check_status(**comp1_status1), comp1_status1)
 
-        comp2_status1 = TransportStatus(
-            component='bar',
-            status='ok',
-            type='bar',
-            message='another test')
-        self.assertEqual(sed.check_status(comp2_status1), comp2_status1)
+        comp2_status1 = {
+            'component': 'bar',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'another test'}
+        self.assertEqual(sed.check_status(**comp2_status1), comp2_status1)
 
-        comp2_status2 = TransportStatus(
-            component='bar',
-            status='degraded',
-            type='bar',
-            message='another test')
-        self.assertEqual(sed.check_status(comp2_status2), comp2_status2)
+        comp2_status2 = {
+            'component': 'bar',
+            'status': 'degraded',
+            'type': 'bar',
+            'message': 'another test'}
+        self.assertEqual(sed.check_status(**comp2_status2), comp2_status2)
 
-        comp1_status2 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='bar',
-            message='test')
-        self.assertEqual(sed.check_status(comp1_status2), None)
+        comp1_status2 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'test'}
+        self.assertEqual(sed.check_status(**comp1_status2), None)
 
     def test_type_change(self):
         '''A change in status type should result in the status being
         returned.'''
         sed = StatusEdgeDetector()
-        status1 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='bar',
-            message='test')
-        self.assertEqual(sed.check_status(status1), status1)
+        status1 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'bar',
+            'message': 'test'}
+        self.assertEqual(sed.check_status(**status1), status1)
 
-        status2 = TransportStatus(
-            component='foo',
-            status='ok',
-            type='baz',
-            message='test')
-        self.assertEqual(sed.check_status(status2), status2)
+        status2 = {
+            'component': 'foo',
+            'status': 'ok',
+            'type': 'baz',
+            'message': 'test'}
+        self.assertEqual(sed.check_status(**status2), status2)

--- a/vumi/transports/httprpc/httprpc.py
+++ b/vumi/transports/httprpc/httprpc.py
@@ -200,8 +200,7 @@ class HttpRpcTransport(Transport):
     def add_status(self, **kw):
         '''Publishes a status if it is not a repeat of the previously
         published status.'''
-        status = TransportStatus(**kw)
-        if self.status_detect.check_status(status):
+        if self.status_detect.check_status(**kw):
             return self.publish_status(**kw)
         return succeed(None)
 

--- a/vumi/transports/httprpc/httprpc.py
+++ b/vumi/transports/httprpc/httprpc.py
@@ -3,7 +3,7 @@
 import json
 
 from twisted.cred.portal import Portal
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, succeed
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from twisted.web import http
@@ -13,8 +13,10 @@ from twisted.web.server import NOT_DONE_YET
 
 from vumi import log
 from vumi.config import ConfigText, ConfigInt, ConfigBool, ConfigError
+from vumi.message import TransportStatus
 from vumi.transports.base import Transport
 from vumi.transports.httprpc.auth import HttpRpcRealm, StaticAuthChecker
+from vumi.utils import StatusEdgeDetector
 
 
 class HttpRpcTransportConfig(Transport.CONFIG_CLASS):
@@ -192,6 +194,16 @@ class HttpRpcTransport(Transport):
                 (HttpRpcHealthResource(self), self.health_path),
             ],
             self.web_port)
+
+        self.status_detect = StatusEdgeDetector()
+
+    def add_status(self, **kw):
+        '''Publishes a status if it is not a repeat of the previously
+        published status.'''
+        status = TransportStatus(**kw)
+        if self.status_detect.check_status(status):
+            return self.publish_status(**kw)
+        return succeed(None)
 
     @inlineCallbacks
     def teardown_transport(self):

--- a/vumi/transports/httprpc/tests/test_httprpc.py
+++ b/vumi/transports/httprpc/tests/test_httprpc.py
@@ -7,7 +7,7 @@ from vumi.utils import http_request, http_request_full, basic_auth_string
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 from vumi.transports.httprpc import HttpRpcTransport
-from vumi.message import TransportUserMessage, TransportStatus
+from vumi.message import TransportUserMessage
 from vumi.transports.tests.helpers import TransportHelper
 
 

--- a/vumi/utils.py
+++ b/vumi/utils.py
@@ -463,7 +463,7 @@ class StatusEdgeDetector(object):
         self.state = dict()
         self.types = dict()
 
-    def check_status(self, status):
+    def check_status(self, **status):
         '''
         Checks to see if the current status is a repeat. If it is, None is
         returned. If it isn't, the status is returned.


### PR DESCRIPTION
We need to add a helper method to the base http rpc transport that makes use of the component added in #1004.