### PR TITLE
Remove get_stubbed_channel

### DIFF
--- a/vumi/blinkenlights/metrics.py
+++ b/vumi/blinkenlights/metrics.py
@@ -75,7 +75,8 @@ class MetricManager(object):
         Stop the metric polling and publishing task.
         """
         if self._task:
-            self._task.stop()
+            if self._task.running:
+                self._task.stop()
             self._task = None
 
     def publish_metrics(self):

--- a/vumi/blinkenlights/tests/test_metrics_workers.py
+++ b/vumi/blinkenlights/tests/test_metrics_workers.py
@@ -2,7 +2,6 @@ from twisted.internet.defer import inlineCallbacks, Deferred, DeferredQueue
 from twisted.internet.protocol import DatagramProtocol
 from twisted.internet import reactor
 
-from vumi.tests.utils import get_stubbed_channel
 from vumi.blinkenlights import metrics_workers
 from vumi.blinkenlights.message20110818 import MetricMessage
 from vumi.tests.helpers import VumiTestCase, WorkerHelper
@@ -269,7 +268,8 @@ class TestGraphitePublisher(VumiTestCase):
     @inlineCallbacks
     def test_publish_metric(self):
         datapoint = ("vumi.test.v1", 1.0, 1234)
-        channel = yield get_stubbed_channel(self.worker_helper.broker)
+        client = WorkerHelper.get_fake_amqp_client(self.worker_helper.broker)
+        channel = yield client.get_channel()
         pub = metrics_workers.GraphitePublisher()
         pub.start(channel)
         pub.publish_metric(*datapoint)

--- a/vumi/tests/utils.py
+++ b/vumi/tests/utils.py
@@ -65,12 +65,6 @@ class StubbedWorkerCreator(WorkerCreator):
         reactor.callLater(0, worker._amqp_connected, amq_client)
 
 
-def get_stubbed_channel(broker=None, id=0):
-    spec = get_spec(vumi_resource_path("amqp-spec-0-8.xml"))
-    amq_client = FakeAMQClient(spec, {}, broker)
-    return amq_client.channel(id)
-
-
 def FakeRedis():
     warnings.warn("Use of FakeRedis is deprecated. "
                   "Use persist.tests.fake_redis instead.",
@@ -517,7 +511,7 @@ class VumiWorkerTestCase(VumiTestCase):
             )
 
     def mkmsg_nack(self, user_message_id='1', transport_metadata=None,
-                    transport_name=None, nack_reason='unknown'):
+                   transport_name=None, nack_reason='unknown'):
         if transport_metadata is None:
             transport_metadata = {}
         if transport_name is None:


### PR DESCRIPTION
`get_stubbed_channel()` is an old test helper that relies on implementation details of `fake_amqp` that are changing soon. It's easily replaced (in the few tests that use it) by a couple of lines that construct an actual channel from a fake client.