### PR TITLE
WorkerHelper should support getting messages after pending deliveries

### DIFF
--- a/vumi/blinkenlights/tests/test_metrics.py
+++ b/vumi/blinkenlights/tests/test_metrics.py
@@ -25,8 +25,9 @@ class TestMetricPublisher(VumiTestCase):
         reactor.callLater(delay, lambda: d.callback(None))
         return d
 
+    @inlineCallbacks
     def _check_msg(self, prefix, metric, values):
-        msgs = self.worker_helper.get_dispatched_metrics()
+        msgs = yield self.worker_helper.wait_for_dispatched_metrics()
         if values is None:
             self.assertEqual(msgs, [])
             return
@@ -86,8 +87,9 @@ class TestMetricManager(VumiTestCase):
         reactor.callLater(delay, lambda: d.callback(None))
         return d
 
+    @inlineCallbacks
     def _check_msg(self, manager, metric, values):
-        msgs = self.worker_helper.get_dispatched_metrics()
+        msgs = yield self.worker_helper.wait_for_dispatched_metrics()
         if values is None:
             self.assertEqual(msgs, [])
             return

--- a/vumi/scripts/tests/test_inject_messages.py
+++ b/vumi/scripts/tests/test_inject_messages.py
@@ -39,7 +39,7 @@ class TestMessageInjector(VumiTestCase):
         worker = yield self.get_worker('inbound')
         data = self.make_data()
         worker.process_line(json.dumps(data))
-        [msg] = self.worker_helper.get_dispatched_inbound()
+        [msg] = yield self.worker_helper.wait_for_dispatched_inbound()
         self.check_msg(msg, data)
 
     @inlineCallbacks
@@ -47,7 +47,7 @@ class TestMessageInjector(VumiTestCase):
         worker = yield self.get_worker('outbound')
         data = self.make_data()
         worker.process_line(json.dumps(data))
-        [msg] = self.worker_helper.get_dispatched_outbound()
+        [msg] = yield self.worker_helper.wait_for_dispatched_outbound()
         self.check_msg(msg, data)
 
     @inlineCallbacks
@@ -58,7 +58,7 @@ class TestMessageInjector(VumiTestCase):
         in_file = StringIO.StringIO(data_string)
         out_file = StringIO.StringIO()
         yield worker.process_file(in_file, out_file)
-        msgs = self.worker_helper.get_dispatched_inbound()
+        msgs = yield self.worker_helper.wait_for_dispatched_inbound()
         for msg, datum in zip(msgs, data):
             self.check_msg(msg, datum)
         self.assertEqual(out_file.getvalue(), data_string + "\n")
@@ -71,7 +71,7 @@ class TestMessageInjector(VumiTestCase):
         in_file = StringIO.StringIO(data_string)
         out_file = StringIO.StringIO()
         yield worker.process_file(in_file, out_file)
-        msgs = self.worker_helper.get_dispatched_outbound()
+        msgs = yield self.worker_helper.wait_for_dispatched_outbound()
         for msg, datum in zip(msgs, data):
             self.check_msg(msg, datum)
         self.assertEqual(out_file.getvalue(), data_string + "\n")

--- a/vumi/tests/helpers.py
+++ b/vumi/tests/helpers.py
@@ -1131,6 +1131,17 @@ class WorkerHelper(object):
         return [json.loads(msg.body)['datapoints'] for msg in msgs]
 
     @proxyable
+    def wait_for_dispatched_metrics(self):
+        """
+        Get dispatched metrics after waiting for any pending deliveries.
+
+        The list of datapoints from each dispatched metrics message is
+        returned.
+        """
+        return self.broker.wait_delivery().addCallback(
+            lambda _: self.get_dispatched_metrics())
+
+    @proxyable
     def clear_dispatched_metrics(self):
         """
         Clear dispatched metrics messages from the broker.

--- a/vumi/tests/helpers.py
+++ b/vumi/tests/helpers.py
@@ -770,13 +770,18 @@ class WorkerHelper(object):
             probably be :class:`~vumi.message.TransportUserMessage` or
             :class:`~vumi.message.TransportEvent`.
         """
-        msgs = self.broker.get_dispatched(
-            'vumi', self._rkey(connector_name, name))
+        rkey = self._rkey(connector_name, name)
+        msgs = self.broker.get_dispatched('vumi', rkey)
         return [message_class.from_json(msg.body) for msg in msgs]
 
     def _wait_for_dispatched(self, connector_name, name, amount):
         rkey = self._rkey(connector_name, name)
-        return self.broker.wait_messages('vumi', rkey, amount)
+        if amount is not None:
+            # The broker knows how to wait for a specific number of messages.
+            return self.broker.wait_messages('vumi', rkey, amount)
+        # Wait for delivery to finish, then return whatever we have.
+        return self.broker.wait_delivery().addCallback(
+            lambda _: self.broker.get_messages('vumi', rkey))
 
     @proxyable
     def clear_all_dispatched(self):
@@ -852,12 +857,14 @@ class WorkerHelper(object):
             connector_name, 'status', TransportStatus)
 
     @proxyable
-    def wait_for_dispatched_events(self, amount, connector_name=None):
+    def wait_for_dispatched_events(self, amount=None, connector_name=None):
         """
         Wait for events dispatched to a connector.
 
         :param int amount:
-            Number of events to wait for.
+            Number of messages to wait for. If ``None``, this will wait for the
+            end of the current delivery run instead of a specific number of
+            messages.
 
         :param str connector_name:
             Connector name. If ``None``, the default connector name for the
@@ -873,12 +880,14 @@ class WorkerHelper(object):
         return d
 
     @proxyable
-    def wait_for_dispatched_inbound(self, amount, connector_name=None):
+    def wait_for_dispatched_inbound(self, amount=None, connector_name=None):
         """
         Wait for inbound messages dispatched to a connector.
 
         :param int amount:
-            Number of messages to wait for.
+            Number of messages to wait for. If ``None``, this will wait for the
+            end of the current delivery run instead of a specific number of
+            messages.
 
         :param str connector_name:
             Connector name. If ``None``, the default connector name for the
@@ -894,12 +903,14 @@ class WorkerHelper(object):
         return d
 
     @proxyable
-    def wait_for_dispatched_outbound(self, amount, connector_name=None):
+    def wait_for_dispatched_outbound(self, amount=None, connector_name=None):
         """
         Wait for outbound messages dispatched to a connector.
 
         :param int amount:
-            Number of messages to wait for.
+            Number of messages to wait for. If ``None``, this will wait for the
+            end of the current delivery run instead of a specific number of
+            messages.
 
         :param str connector_name:
             Connector name. If ``None``, the default connector name for the
@@ -915,12 +926,14 @@ class WorkerHelper(object):
         return d
 
     @proxyable
-    def wait_for_dispatched_statuses(self, amount, connector_name=None):
+    def wait_for_dispatched_statuses(self, amount=None, connector_name=None):
         """
         Wait for statuses dispatched to a connector.
 
         :param int amount:
-            Number of events to wait for.
+            Number of messages to wait for. If ``None``, this will wait for the
+            end of the current delivery run instead of a specific number of
+            messages.
 
         :param str connector_name:
             Connector name. If ``None``, the default status connector name for

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -1004,6 +1004,25 @@ class TestWorkerHelper(VumiTestCase):
         self.assertEqual(dispatched, [msg])
 
     @inlineCallbacks
+    def test_wait_for_dispatched_events_no_amount(self):
+        """
+        WorkerHelper.wait_for_dispatched_events() with no amount specified
+        waits for any pending deliveries to finish and then returns all
+        dispatched events.
+        """
+        msg_helper = MessageHelper()
+        worker_helper = WorkerHelper()
+        d = worker_helper.wait_for_dispatched_events(connector_name='fooconn')
+        self.assertEqual(self.successResultOf(d), [])
+
+        msg = msg_helper.make_ack()
+        self._add_to_dispatched(worker_helper.broker, 'fooconn.event', msg)
+        d = worker_helper.wait_for_dispatched_events(connector_name='fooconn')
+        self.assertNoResult(d)
+        yield worker_helper.broker.wait_delivery()
+        self.assertEqual(self.successResultOf(d), [msg])
+
+    @inlineCallbacks
     def test_wait_for_dispatched_events_no_connector(self):
         """
         WorkerHelper.wait_for_dispatched_events() should get use the default
@@ -1028,11 +1047,31 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         d = worker_helper.wait_for_dispatched_inbound(1, 'fooconn')
+        self.assertNoResult(d)
         msg = msg_helper.make_inbound('message')
         yield self._add_to_dispatched(
             worker_helper.broker, 'fooconn.inbound', msg, kick=True)
         dispatched = success_result_of(d)
         self.assertEqual(dispatched, [msg])
+
+    @inlineCallbacks
+    def test_wait_for_dispatched_inbound_no_amount(self):
+        """
+        WorkerHelper.wait_for_dispatched_inbound() with no amount specified
+        waits for any pending deliveries to finish and then returns all
+        dispatched inbound messages.
+        """
+        msg_helper = MessageHelper()
+        worker_helper = WorkerHelper()
+        d = worker_helper.wait_for_dispatched_inbound(connector_name='fooconn')
+        self.assertEqual(self.successResultOf(d), [])
+
+        msg = msg_helper.make_inbound('message')
+        self._add_to_dispatched(worker_helper.broker, 'fooconn.inbound', msg)
+        d = worker_helper.wait_for_dispatched_inbound(connector_name='fooconn')
+        self.assertNoResult(d)
+        yield worker_helper.kick_delivery()
+        self.assertEqual(self.successResultOf(d), [msg])
 
     @inlineCallbacks
     def test_wait_for_dispatched_inbound_no_connector(self):
@@ -1043,6 +1082,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
         d = worker_helper.wait_for_dispatched_inbound(1)
+        self.assertNoResult(d)
         msg = msg_helper.make_inbound('message')
         yield self._add_to_dispatched(
             worker_helper.broker, 'fooconn.inbound', msg, kick=True)
@@ -1058,11 +1098,33 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         d = worker_helper.wait_for_dispatched_outbound(1, 'fooconn')
+        self.assertNoResult(d)
         msg = msg_helper.make_outbound('message')
         yield self._add_to_dispatched(
             worker_helper.broker, 'fooconn.outbound', msg, kick=True)
         dispatched = success_result_of(d)
         self.assertEqual(dispatched, [msg])
+
+    @inlineCallbacks
+    def test_wait_for_dispatched_outbound_no_amount(self):
+        """
+        WorkerHelper.wait_for_dispatched_outbound() with no amount specified
+        waits for any pending deliveries to finish and then returns all
+        dispatched outbound messages.
+        """
+        msg_helper = MessageHelper()
+        worker_helper = WorkerHelper()
+        d = worker_helper.wait_for_dispatched_outbound(
+            connector_name='fooconn')
+        self.assertEqual(self.successResultOf(d), [])
+
+        msg = msg_helper.make_outbound('message')
+        self._add_to_dispatched(worker_helper.broker, 'fooconn.outbound', msg)
+        d = worker_helper.wait_for_dispatched_outbound(
+            connector_name='fooconn')
+        self.assertNoResult(d)
+        yield worker_helper.kick_delivery()
+        self.assertEqual(self.successResultOf(d), [msg])
 
     @inlineCallbacks
     def test_wait_for_dispatched_outbound_no_connector(self):
@@ -1088,6 +1150,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         d = worker_helper.wait_for_dispatched_statuses(1, 'fooconn')
+        self.assertNoResult(d)
 
         msg = msg_helper.make_status(
             status='down',
@@ -1099,6 +1162,31 @@ class TestWorkerHelper(VumiTestCase):
             worker_helper.broker, 'fooconn.status', msg, kick=True)
         dispatched = success_result_of(d)
         self.assertEqual(dispatched, [msg])
+
+    @inlineCallbacks
+    def test_wait_for_dispatched_statuses_no_amount(self):
+        """
+        WorkerHelper.wait_for_dispatched_statuses() with no amount specified
+        waits for any pending deliveries to finish and then returns all
+        dispatched statuses.
+        """
+        msg_helper = MessageHelper()
+        worker_helper = WorkerHelper()
+        d = worker_helper.wait_for_dispatched_statuses(
+            connector_name='fooconn')
+        self.assertEqual(self.successResultOf(d), [])
+
+        msg = msg_helper.make_status(
+            status='down',
+            component='foo',
+            type='bar',
+            message='baz')
+        self._add_to_dispatched(worker_helper.broker, 'fooconn.status', msg)
+        d = worker_helper.wait_for_dispatched_statuses(
+            connector_name='fooconn')
+        self.assertNoResult(d)
+        yield worker_helper.kick_delivery()
+        self.assertEqual(self.successResultOf(d), [msg])
 
     @inlineCallbacks
     def test_wait_for_dispatched_statuses_no_connector(self):

--- a/vumi/transports/xmpp/tests/test_xmpp.py
+++ b/vumi/transports/xmpp/tests/test_xmpp.py
@@ -95,7 +95,7 @@ class TestXMPPTransport(VumiTestCase):
         message.addElement((None, 'body'), content='hello world')
         protocol = transport.xmpp_protocol
         protocol.onMessage(message)
-        [msg] = self.tx_helper.get_dispatched_inbound()
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound()
         self.assertEqual(msg['to_addr'], self.jid.userhost())
         self.assertEqual(msg['from_addr'], 'test@case.com')
         self.assertEqual(msg['transport_name'], self.tx_helper.transport_name)
@@ -116,7 +116,7 @@ class TestXMPPTransport(VumiTestCase):
         protocol = transport.xmpp_protocol
         protocol.onMessage(message)
 
-        [msg] = self.tx_helper.get_dispatched_inbound()
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound()
         self.assertTrue(msg['message_id'])
         self.assertEqual(msg['transport_metadata']['xmpp_id'], None)
 
@@ -194,6 +194,6 @@ class TestXMPPTransport(VumiTestCase):
         message.addElement((None, 'body'), content='hello world')
         protocol = transport.xmpp_protocol
         protocol.onMessage(message)
-        [msg] = self.tx_helper.get_dispatched_inbound()
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound()
         self.assertEqual(msg['from_addr'], 'test@case.com')
         self.assertEqual(msg['transport_metadata']['xmpp_id'], message['id'])


### PR DESCRIPTION
At the moment, we can either get current messages or wait for a specific number of messages. It would be useful to be able to wait for any pending deliveries to complete and then get whatever messages are available. (This is particularly helpful for #1000, which breaks the assumption that the client can wait for the broker to receive published messages.)

In order to maintain compatibility while avoiding API bloat, I'm making the `amount` parameter optional in the various `WorkerHelper.wait_for_dispatched_*` methods and treating a value of `None` (the default) as an indication that we should wait for pending deliveries to finish instead of waiting for a particular number of messages.