### PR TITLE
Change response time to base transport calling subclass

### DIFF
--- a/vumi/transports/dmark/dmark_ussd.py
+++ b/vumi/transports/dmark/dmark_ussd.py
@@ -147,8 +147,6 @@ class DmarkUssdTransport(HttpRpcTransport):
                 details=errors)
             return
 
-        yield self.set_request_start(request_id)
-
         yield self.add_status(
             component='request',
             status='ok',
@@ -198,8 +196,6 @@ class DmarkUssdTransport(HttpRpcTransport):
         response_id = self.finish_request(
             message['in_reply_to'], json.dumps(response_data))
 
-        yield self.set_request_end(message['in_reply_to'])
-
         if response_id is not None:
             ack = yield self.publish_ack(
                 user_message_id=message['message_id'],
@@ -211,3 +207,53 @@ class DmarkUssdTransport(HttpRpcTransport):
                 sent_message_id=message['message_id'],
                 reason="Could not find original request.")
             returnValue(nack)
+
+    def on_down_response_time(self, message_id, time):
+        request = self.get_request(message_id)
+        # We send different status events for error responses
+        if request.code < 200 or request.code >= 300:
+            return
+        return self.add_status(
+            component='response',
+            status='down',
+            type='slow_response',
+            message='Very slow response',
+            reasons=[
+                'Response took longer than %fs' % (
+                    self.response_time_down,)
+            ],
+            details={
+                'response_time': time,
+            })
+
+    def on_degraded_response_time(self, message_id, time):
+        request = self.get_request(message_id)
+        # We send different status events for error responses
+        if request.code < 200 or request.code >= 300:
+            return
+        return self.add_status(
+            component='response',
+            status='degraded',
+            type='slow_response',
+            message='Slow response',
+            reasons=[
+                'Response took longer than %fs' % (
+                    self.response_time_degraded,)
+            ],
+            details={
+                'response_time': time,
+            })
+
+    def on_good_response_time(self, message_id, time):
+        request = self.get_request(message_id)
+        # We send different status events for error responses
+        if request.code < 200 or request.code >= 300:
+            return
+        return self.add_status(
+            component='response',
+            status='ok',
+            type='response_sent',
+            message='Response sent',
+            details={
+                'response_time': time,
+            })

--- a/vumi/transports/dmark/dmark_ussd.py
+++ b/vumi/transports/dmark/dmark_ussd.py
@@ -247,7 +247,7 @@ class DmarkUssdTransport(HttpRpcTransport):
     def on_good_response_time(self, message_id, time):
         request = self.get_request(message_id)
         # We send different status events for error responses
-        if request.code < 200 or request.code >= 300:
+        if request.code < 200 or request.code >= 400:
             return
         return self.add_status(
             component='response',

--- a/vumi/transports/dmark/dmark_ussd.py
+++ b/vumi/transports/dmark/dmark_ussd.py
@@ -216,7 +216,7 @@ class DmarkUssdTransport(HttpRpcTransport):
         return self.add_status(
             component='response',
             status='down',
-            type='slow_response',
+            type='very_slow_response',
             message='Very slow response',
             reasons=[
                 'Response took longer than %fs' % (

--- a/vumi/transports/dmark/tests/test_dmark_ussd.py
+++ b/vumi/transports/dmark/tests/test_dmark_ussd.py
@@ -349,3 +349,58 @@ class TestDmarkUssdTransport(VumiTestCase):
         self.tx_helper.dispatch_outbound(reply)
         statuses = yield self.tx_helper.get_dispatched_statuses()
         self.assertEqual(len(statuses), 0)
+
+    @inlineCallbacks
+    def test_no_good_status_event_for_bad_responses(self):
+        '''If the http response is not a good (200-399) response, then a
+        status event shouldn't be sent, because we send different status
+        events for those errors.'''
+        d = self.tx_helper.mk_request()
+
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+        yield self.tx_helper.clear_dispatched_statuses()
+
+        self.transport.finish_request(msg['message_id'], '', code=500)
+
+        response = yield d
+
+        statuses = yield self.tx_helper.get_dispatched_statuses()
+        self.assertEqual(len(statuses), 0)
+
+    @inlineCallbacks
+    def test_no_degraded_status_event_for_bad_responses(self):
+        '''If the http response is not a good (200-399) response, then a
+        status event shouldn't be sent, because we send different status
+        events for those errors.'''
+        d = self.tx_helper.mk_request()
+
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+        yield self.tx_helper.clear_dispatched_statuses()
+
+        self.clock.advance(self.transport.response_time_degraded + 0.1)
+
+        self.transport.finish_request(msg['message_id'], '', code=500)
+
+        response = yield d
+
+        statuses = yield self.tx_helper.get_dispatched_statuses()
+        self.assertEqual(len(statuses), 0)
+
+    @inlineCallbacks
+    def test_no_down_status_event_for_bad_responses(self):
+        '''If the http response is not a good (200-399) response, then a
+        status event shouldn't be sent, because we send different status
+        events for those errors.'''
+        d = self.tx_helper.mk_request()
+
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+        yield self.tx_helper.clear_dispatched_statuses()
+
+        self.clock.advance(self.transport.response_time_down + 0.1)
+
+        self.transport.finish_request(msg['message_id'], '', code=500)
+
+        response = yield d
+
+        statuses = yield self.tx_helper.get_dispatched_statuses()
+        self.assertEqual(len(statuses), 0)

--- a/vumi/transports/dmark/tests/test_dmark_ussd.py
+++ b/vumi/transports/dmark/tests/test_dmark_ussd.py
@@ -336,7 +336,7 @@ class TestDmarkUssdTransport(VumiTestCase):
         self.assertTrue(
             str(self.transport.response_time_down) in status['reasons'][0])
         self.assertEqual(status['component'], 'response')
-        self.assertEqual(status['type'], 'slow_response')
+        self.assertEqual(status['type'], 'very_slow_response')
         self.assertEqual(status['message'], 'Very slow response')
 
     @inlineCallbacks


### PR DESCRIPTION
Currently, the subclass for the http transport needs to call `set_request_start` and `set_request_end` in the base function to be able to send status events for long response times. Change this to have the base httprpc transport calculate the times, and if they exceed the configured values, call a function in the subclass transport that has the logic to do the correct thing (for dmark, send the relevant status event).