### PR TITLE
Fix publisher exchange setup

### DIFF
--- a/vumi/service.py
+++ b/vumi/service.py
@@ -443,6 +443,8 @@ class DynamicPublisher(_Publisher):
     A single-routing-key publisher.
     """
 
+    durable = True
+
     def __init__(self, channel, routing_key):
         self.channel = channel
         self.check_routing_key(routing_key)

--- a/vumi/tests/test_fake_amqp.py
+++ b/vumi/tests/test_fake_amqp.py
@@ -39,7 +39,7 @@ class TestFakeAMQP(VumiTestCase):
         self.add_cleanup(self.broker.wait_delivery)
 
     def make_exchange(self, exchange, exchange_type):
-        self.broker.exchange_declare(exchange, exchange_type)
+        self.broker.exchange_declare(exchange, exchange_type, durable=True)
         return self.broker.exchanges[exchange]
 
     def make_queue(self, queue):
@@ -86,10 +86,10 @@ class TestFakeAMQP(VumiTestCase):
     def test_exchange_declare(self):
         channel = self.make_channel(0)
         self.assertEqual({}, self.broker.exchanges)
-        channel.exchange_declare('foo', 'direct')
+        channel.exchange_declare('foo', 'direct', durable=True)
         self.assertEqual(['foo'], self.broker.exchanges.keys())
         self.assertEqual('direct', self.broker.exchanges['foo'].exchange_type)
-        channel.exchange_declare('bar', 'topic')
+        channel.exchange_declare('bar', 'topic', durable=True)
         self.assertEqual(['bar', 'foo'], sorted(self.broker.exchanges.keys()))
         self.assertEqual('topic', self.broker.exchanges['bar'].exchange_type)
 
@@ -238,7 +238,7 @@ class TestFakeAMQP(VumiTestCase):
 
         delegate = ToyDelegate()
         channel = self.make_channel(0, delegate)
-        channel.exchange_declare('e1', 'direct')
+        channel.exchange_declare('e1', 'direct', durable=True)
         channel.queue_declare('q1')
         channel.queue_bind('q1', 'e1', 'rkey')
         channel.basic_consume('q1', 'tag1')
@@ -269,7 +269,7 @@ class TestFakeAMQP(VumiTestCase):
 
         delegate = ToyDelegate()
         channel = self.make_channel(0, delegate)
-        channel.exchange_declare('e1', 'direct')
+        channel.exchange_declare('e1', 'direct', durable=True)
         channel.queue_declare('q1')
         channel.queue_bind('q1', 'e1', 'rkey')
         channel.basic_consume('q1', 'tag1')

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -784,13 +784,13 @@ class TestWorkerHelper(VumiTestCase):
         self.assertFalse(worker.worker_started)
 
     def _add_to_dispatched(self, broker, rkey, msg, kick=False):
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         broker.publish_message('vumi', rkey, msg)
         if kick:
             return broker.kick_delivery()
 
     def _add_to_dispatched_metrics(self, broker, msg):
-        broker.exchange_declare('vumi.metrics', 'direct')
+        broker.exchange_declare('vumi.metrics', 'direct', durable=True)
         broker.publish_message('vumi.metrics', 'vumi.metrics', msg)
 
     def test_get_dispatched(self):
@@ -1361,7 +1361,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.foo'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_raw('fooconn.foo', msg)
@@ -1376,7 +1376,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         broker = worker_helper.broker
-        broker.exchange_declare('blah', 'direct')
+        broker.exchange_declare('blah', 'direct', durable=True)
         self.assertEqual(broker.get_messages('blah', 'fooconn.foo'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_raw('fooconn.foo', msg, exchange='blah')
@@ -1390,7 +1390,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = msg_helper.make_ack()
         yield worker_helper.dispatch_event(msg, 'fooconn')
@@ -1405,7 +1405,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = msg_helper.make_ack()
         yield worker_helper.dispatch_event(msg)
@@ -1419,7 +1419,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_inbound(msg, 'fooconn')
@@ -1434,7 +1434,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_inbound(msg)
@@ -1448,7 +1448,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = msg_helper.make_outbound('message')
         yield worker_helper.dispatch_outbound(msg, 'fooconn')
@@ -1464,7 +1464,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = msg_helper.make_outbound('message')
         yield worker_helper.dispatch_outbound(msg)
@@ -1479,7 +1479,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
 
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
@@ -1503,7 +1503,7 @@ class TestWorkerHelper(VumiTestCase):
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(status_connector_name='fooconn')
         broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
 
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
@@ -1608,7 +1608,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = yield md_helper.make_dispatch_inbound('inbound message')
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [msg])
@@ -1631,7 +1631,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = yield md_helper.make_dispatch_inbound(
             'inbound message', from_addr='ib_from', to_addr='ib_to')
@@ -1655,7 +1655,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = yield md_helper.make_dispatch_outbound('outbound message')
         self.assertEqual(
@@ -1679,7 +1679,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = yield md_helper.make_dispatch_outbound(
             'outbound message', from_addr='ob_from', to_addr='ob_to')
@@ -1703,7 +1703,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         event = yield md_helper.make_dispatch_ack()
         self.assertEqual(
@@ -1722,7 +1722,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = md_helper.msg_helper.make_outbound('test message')
         event = yield md_helper.make_dispatch_ack(
@@ -1743,7 +1743,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         event = yield md_helper.make_dispatch_nack()
         self.assertEqual(
@@ -1762,7 +1762,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = md_helper.msg_helper.make_outbound('test message')
         event = yield md_helper.make_dispatch_nack(
@@ -1784,7 +1784,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         event = yield md_helper.make_dispatch_delivery_report()
         self.assertEqual(
@@ -1803,7 +1803,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = md_helper.msg_helper.make_outbound('test message')
         event = yield md_helper.make_dispatch_delivery_report(
@@ -1824,7 +1824,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = md_helper.msg_helper.make_inbound('inbound')
         reply = yield md_helper.make_dispatch_reply(msg, 'reply content')
@@ -1845,7 +1845,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
         broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = yield md_helper.make_dispatch_status(

--- a/vumi/tests/test_test_helpers.py
+++ b/vumi/tests/test_test_helpers.py
@@ -643,6 +643,11 @@ class ToyWorker(BaseWorker):
 
 
 class TestWorkerHelper(VumiTestCase):
+    def setup_broker(self, worker_helper):
+        broker = worker_helper.broker
+        broker.exchange_declare('vumi', 'direct', durable=True)
+        return broker
+
     def test_implements_IHelper(self):
         """
         WorkerHelper instances should provide the IHelper interface.
@@ -1360,8 +1365,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.foo'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_raw('fooconn.foo', msg)
@@ -1389,8 +1393,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = msg_helper.make_ack()
         yield worker_helper.dispatch_event(msg, 'fooconn')
@@ -1404,8 +1407,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = msg_helper.make_ack()
         yield worker_helper.dispatch_event(msg)
@@ -1418,8 +1420,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_inbound(msg, 'fooconn')
@@ -1433,8 +1434,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = msg_helper.make_inbound('message')
         yield worker_helper.dispatch_inbound(msg)
@@ -1447,8 +1447,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = msg_helper.make_outbound('message')
         yield worker_helper.dispatch_outbound(msg, 'fooconn')
@@ -1463,8 +1462,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(connector_name='fooconn')
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = msg_helper.make_outbound('message')
         yield worker_helper.dispatch_outbound(msg)
@@ -1478,8 +1476,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper()
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
 
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
@@ -1502,8 +1499,7 @@ class TestWorkerHelper(VumiTestCase):
         """
         msg_helper = MessageHelper()
         worker_helper = WorkerHelper(status_connector_name='fooconn')
-        broker = worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(worker_helper)
 
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
@@ -1580,6 +1576,11 @@ class TestMessageDispatchHelper(VumiTestCase):
         self.assertEqual(field_dict, dict(
             (k, v) for k, v in msg.payload.iteritems() if k in field_dict))
 
+    def setup_broker(self, md_helper):
+        broker = md_helper.worker_helper.broker
+        broker.exchange_declare('vumi', 'direct', durable=True)
+        return broker
+
     def test_implements_IHelper(self):
         """
         MessageDispatchHelper instances should provide the IHelper interface.
@@ -1607,8 +1608,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = yield md_helper.make_dispatch_inbound('inbound message')
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [msg])
@@ -1630,8 +1630,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.inbound'), [])
         msg = yield md_helper.make_dispatch_inbound(
             'inbound message', from_addr='ib_from', to_addr='ib_to')
@@ -1654,8 +1653,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = yield md_helper.make_dispatch_outbound('outbound message')
         self.assertEqual(
@@ -1678,8 +1676,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = yield md_helper.make_dispatch_outbound(
             'outbound message', from_addr='ob_from', to_addr='ob_to')
@@ -1702,8 +1699,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         event = yield md_helper.make_dispatch_ack()
         self.assertEqual(
@@ -1721,8 +1717,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = md_helper.msg_helper.make_outbound('test message')
         event = yield md_helper.make_dispatch_ack(
@@ -1742,8 +1737,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         event = yield md_helper.make_dispatch_nack()
         self.assertEqual(
@@ -1761,8 +1755,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = md_helper.msg_helper.make_outbound('test message')
         event = yield md_helper.make_dispatch_nack(
@@ -1783,8 +1776,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         event = yield md_helper.make_dispatch_delivery_report()
         self.assertEqual(
@@ -1802,8 +1794,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.event'), [])
         msg = md_helper.msg_helper.make_outbound('test message')
         event = yield md_helper.make_dispatch_delivery_report(
@@ -1823,8 +1814,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.outbound'), [])
         msg = md_helper.msg_helper.make_inbound('inbound')
         reply = yield md_helper.make_dispatch_reply(msg, 'reply content')
@@ -1844,8 +1834,7 @@ class TestMessageDispatchHelper(VumiTestCase):
         """
         md_helper = MessageDispatchHelper(
             MessageHelper(), WorkerHelper('fooconn'))
-        broker = md_helper.worker_helper.broker
-        broker.exchange_declare('vumi', 'direct', durable=True)
+        broker = self.setup_broker(md_helper)
         self.assertEqual(broker.get_messages('vumi', 'fooconn.status'), [])
 
         msg = yield md_helper.make_dispatch_status(

--- a/vumi/transports/tests/test_test_helpers.py
+++ b/vumi/transports/tests/test_test_helpers.py
@@ -114,7 +114,7 @@ class TestTransportHelper(VumiTestCase):
         self.assertIsInstance(app, RunningCheckTransport)
 
     def _add_to_dispatched(self, broker, rkey, msg):
-        broker.exchange_declare('vumi', 'direct')
+        broker.exchange_declare('vumi', 'direct', durable=True)
         broker.publish_message('vumi', rkey, msg)
 
     def test_get_dispatched_failures(self):


### PR DESCRIPTION
When we changed how dynamic publishers work, we somehow lost the `durable=True` that was applied to the exchange creation. This wasn't caught in tests because FakeAMQP ignores the `durable` param on exchanges.