### PR TITLE
Remove support for Python 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ node_js:
   - "0.10"
 matrix:
   include:
-    # New Twisted no longer supports Python 2.6. Until we make a proper
-    # decision, the 2.6 build gets an older Twisted.
-    - python: "2.6"
-      env: TWISTED_VERSION="Twisted<15.5.0"
     # Test against the oldest version of Twisted that we claim to support.
     # Also test against Riak 2.1.1.
     # This is a separate matrix inclusion to avoid spawning unnecessary builds.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Networking',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 # This will initialize and run the Vumi test suite in given environments.
 
 [tox]
-envlist = py26, py27
+envlist = py27
 
 [testenv]
 sitepackages = false


### PR DESCRIPTION
The very last release of Python 2.6 was on October 29, 2013 (https://www.python.org/download/releases/2.6.9/). Many libraries we depend on (Twisted, treq) no longer support Python 2.6.