### PR TITLE
Add response error constant to Redis managers so that exceptions can be caught sanely.

### DIFF
--- a/vumi/persist/redis_manager.py
+++ b/vumi/persist/redis_manager.py
@@ -1,9 +1,11 @@
 # -*- test-case-name: vumi.persist.tests.test_redis_manager -*-
 
 import redis
+import redis.exceptions
 
 from vumi.persist.redis_base import Manager
-from vumi.persist.fake_redis import FakeRedis
+from vumi.persist.fake_redis import (
+    FakeRedis, ResponseError as FakeResponseError)
 from vumi.utils import flatten_generator
 
 
@@ -48,6 +50,8 @@ class VumiRedis(redis.Redis):
 
 class RedisManager(Manager):
 
+    RESPONSE_ERROR = redis.exceptions.ResponseError
+
     call_decorator = staticmethod(flatten_generator)
 
     @classmethod
@@ -58,6 +62,7 @@ class RedisManager(Manager):
         manager = cls(fake_redis, **manager_config)
         # Because ._close() assumes a real connection.
         manager._close = fake_redis.teardown
+        manager.RESPONSE_ERROR = FakeResponseError
         return manager
 
     @classmethod

--- a/vumi/persist/tests/test_fake_redis.py
+++ b/vumi/persist/tests/test_fake_redis.py
@@ -633,7 +633,8 @@ class TestFakeRedis(FakeRedisUnverifiedTestMixin, FakeRedisTestMixin,
         self.assertEqual(expected, getattr(redis, op)(*args, **kw))
 
     def assert_redis_error(self, redis, op, *args, **kw):
-        self.assertRaises(Exception, getattr(redis, op), *args, **kw)
+        self.assertRaises(
+            ResponseError, getattr(redis, op), *args, **kw)
 
     def wait(self, redis, delay):
         redis.clock.advance(delay)
@@ -653,7 +654,7 @@ class TestFakeRedisAsync(FakeRedisUnverifiedTestMixin, FakeRedisTestMixin,
 
     def assert_redis_error(self, redis, op, *args, **kw):
         d = getattr(redis, op)(*args, **kw)
-        return self.assertFailure(d, Exception)
+        return self.assertFailure(d, ResponseError)
 
     def wait(self, redis, delay):
         redis.clock.advance(delay)

--- a/vumi/persist/tests/test_fake_redis.py
+++ b/vumi/persist/tests/test_fake_redis.py
@@ -696,11 +696,14 @@ class RedisPairWrapper(object):
 
         # First, handle errors.
         if errors:
-            # We match based on the exception type name so that ResponseErrors
-            # from different places are considered equal. We ignore the error
-            # message in the check, but we display it to aid debugging.
+            # We convert ResponseErrors from the real redis to the fake redis
+            # ResponseError type. We ignore the error message in the check, but
+            # we display it to aid debugging.
+            fake_type, real_type = type(errors[0]), type(errors[1])
+            if real_type is self._real_redis.RESPONSE_ERROR:
+                real_type = self._fake_redis.RESPONSE_ERROR
             self._test_case.assertEqual(
-                type(errors[0]).__name__, type(errors[1]).__name__,
+                fake_type, real_type,
                 ("Fake redis (a) and real redis (b) errors different:"
                  "\n a = %r\n b = %r") % tuple(errors))
             raise errors[0]
@@ -725,8 +728,11 @@ class TestFakeRedisVerify(FakeRedisTestMixin, VumiTestCase):
     def get_redis(self, **kwargs):
         from vumi.persist.redis_manager import RedisManager
         # Fake redis
-        fake_redis = FakeRedis(**kwargs)
-        self.add_cleanup(fake_redis.teardown)
+        fake_redis = RedisManager._fake_manager(FakeRedis(**kwargs), {
+            "config": {},
+            "key_prefix": 'redistest',
+        })
+        self.add_cleanup(fake_redis._close)
         # Real redis
         config = {
             'FAKE_REDIS': 'yes',
@@ -750,7 +756,7 @@ class TestFakeRedisVerify(FakeRedisTestMixin, VumiTestCase):
         self.assertRaises(ResponseError, getattr(redis, op), *args, **kw)
 
     def wait(self, redis, delay):
-        redis._fake_redis.clock.advance(delay)
+        redis._fake_redis._client.clock.advance(delay)
         d = Deferred()
         reactor.callLater(delay, d.callback, None)
         return d
@@ -766,8 +772,12 @@ class TestFakeRedisVerifyAsync(FakeRedisTestMixin, VumiTestCase):
     def get_redis(self, **kwargs):
         from vumi.persist.txredis_manager import TxRedisManager
         # Fake redis
-        fake_redis = FakeRedis(async=True, **kwargs)
-        self.add_cleanup(fake_redis.teardown)
+        fake_redis = yield TxRedisManager._fake_manager(
+            FakeRedis(async=True, **kwargs), {
+                "config": {},
+                "key_prefix": 'redistest',
+            })
+        self.add_cleanup(fake_redis._close)
         # Real redis
         config = {
             'FAKE_REDIS': 'yes',
@@ -795,7 +805,7 @@ class TestFakeRedisVerifyAsync(FakeRedisTestMixin, VumiTestCase):
         return self.assertFailure(d, ResponseError)
 
     def wait(self, redis, delay):
-        redis._fake_redis.clock.advance(delay)
+        redis._fake_redis._client.clock.advance(delay)
         d = Deferred()
         reactor.callLater(delay, d.callback, None)
         return d


### PR DESCRIPTION
Currently one has to do:
```python
try:
    redis.op(...)
except Exception:
    ...
```
for most redis operations because the class of exception raised depends on the kind of redis one has (sync, async, or fake).

Adding a `RESPONSE_ERROR` attribute to the redis manager would allow us to do:
```
try:
    redis.op(...)
except redis.RESPONSE_ERROR:
    ...
```
Much nicer.