### PR TITLE
Fix manhole middleware tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - "pip install 'pip>=7.1.0'"
   - "pip install ${TWISTED_VERSION}"
   # If requested, install PyCrypto
-  - if [ ! -z "$PYCRYPTO_VERSION" ]; then pip install "$PYCRYPTO_VERSION"
+  - if [ ! -z "$PYCRYPTO_VERSION" ]; then pip install "$PYCRYPTO_VERSION"; fi
   - "pip install -r requirements.pip"
   - "pip install coveralls"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ matrix:
     # Although there are two different things we're testing against here, they
     # are orthogonal and any failures should be easily attributable to either
     # Twisted version or Riak version without adding an additional build job.
+    # Twisted 13.2 requires PyCrypto for twisted.conch.ssh support.
     - python: "2.7"
-      env: TWISTED_VERSION="Twisted==13.2.0" RIAK_VERSION="2.1.1"
+      env: TWISTED_VERSION="Twisted==13.2.0" RIAK_VERSION="2.1.1" PYCRYPTO_VERSION="PyCrypto==2.6.1"
     # Test on pypy without coverage, because it's unnecessary and very slow.
     # Also, we hit an obscure GC bug in pypy<=2.6.0 so we need at least 2.6.1.
     - python: "pypy"
@@ -40,6 +41,8 @@ install:
   # Travis seems to have pip 6.x, which doesn't build and cache wheels.
   - "pip install 'pip>=7.1.0'"
   - "pip install ${TWISTED_VERSION}"
+  # If requested, install PyCrypto
+  - if [ ! -z "$PYCRYPTO_VERSION" ]; then pip install "$PYCRYPTO_VERSION"
   - "pip install -r requirements.pip"
   - "pip install coveralls"
 

--- a/vumi/middleware/manhole.py
+++ b/vumi/middleware/manhole.py
@@ -6,13 +6,11 @@ from vumi.middleware import BaseMiddleware
 from vumi.middleware.base import BaseMiddlewareConfig
 from vumi.config import ConfigServerEndpoint
 
-from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.cred import portal
 from twisted.conch import manhole_ssh, manhole_tap
 from twisted.conch.checkers import SSHPublicKeyDatabase
 from twisted.python.filepath import FilePath
-from twisted.internet.endpoints import serverFromString
 
 
 class ManholeMiddlewareConfig(BaseMiddlewareConfig):
@@ -73,8 +71,7 @@ class ManholeMiddleware(BaseMiddleware):
         })
         ssh_portal = portal.Portal(ssh_realm, [checker])
         factory = manhole_ssh.ConchFactory(ssh_portal)
-        endpoint = serverFromString(reactor, self.twisted_endpoint)
-        self.socket = yield endpoint.listen(factory)
+        self.socket = yield self.twisted_endpoint.listen(factory)
 
     def teardown_middleware(self):
         return self.socket.stopListening()

--- a/vumi/middleware/manhole.py
+++ b/vumi/middleware/manhole.py
@@ -18,7 +18,7 @@ from twisted.internet.endpoints import serverFromString
 class ManholeMiddlewareConfig(BaseMiddlewareConfig):
     twisted_endpoint = ConfigServerEndpoint(
         "Twisted endpoint to listen on", default="tcp:0", static=True)
-    autorized_keys = ConfigList(
+    authorized_keys = ConfigList(
         "List of absolute paths to `authorized_keys` files containing SSH "
         "public keys that are allowed access.", default=None, static=True)
 

--- a/vumi/middleware/manhole_utils.py
+++ b/vumi/middleware/manhole_utils.py
@@ -27,10 +27,10 @@ class ClientUserAuth(userauth.SSHUserAuthClient):
         return
 
     def getPublicKey(self):
-        return public_key.blob()
+        return public_key
 
     def getPrivateKey(self):
-        return defer.succeed(private_key.keyObject)
+        return defer.succeed(private_key)
 
 
 class ClientConnection(connection.SSHConnection):


### PR DESCRIPTION
These tests suddenly run under Travis with Twisted 16.0 (yay!), but are very broken (eep!).