### PR TITLE
Fix fake_connection abortConnection under Twisted 16.1

### DIFF
--- a/vumi/tests/fake_connection.py
+++ b/vumi/tests/fake_connection.py
@@ -220,14 +220,12 @@ def patch_transport_abortConnection(transport, protocol):
     Patch abortConnection() onto the transport if it doesn't already have it.
     (`Agent` assumes its transport has this.)
     """
-    _old_abortConnection = getattr(transport, 'abortConnection', None)
+    _old_abortConnection = getattr(
+        transport, 'abortConnection', transport.loseConnection)
 
     def abortConnection():
         protocol._fake_connection_aborted = True
-        if _old_abortConnection:
-            _old_abortConnection()
-        else:
-            transport.loseConnection()
+        _old_abortConnection()
 
     transport.abortConnection = abortConnection
 

--- a/vumi/tests/fake_connection.py
+++ b/vumi/tests/fake_connection.py
@@ -220,10 +220,16 @@ def patch_transport_abortConnection(transport, protocol):
     Patch abortConnection() onto the transport if it doesn't already have it.
     (`Agent` assumes its transport has this.)
     """
+    _old_abortConnection = getattr(transport, 'abortConnection', None)
+
     def abortConnection():
         protocol._fake_connection_aborted = True
-        transport.loseConnection()
-    patch_if_missing(transport, 'abortConnection', abortConnection)
+        if _old_abortConnection:
+            _old_abortConnection()
+        else:
+            transport.loseConnection()
+
+    transport.abortConnection = abortConnection
 
 
 class FakeServerProtocolWrapper(Protocol):

--- a/vumi/tests/fake_connection.py
+++ b/vumi/tests/fake_connection.py
@@ -217,8 +217,12 @@ def patch_transport_fake_push_producer(transport):
 
 def patch_transport_abortConnection(transport, protocol):
     """
-    Patch abortConnection() onto the transport if it doesn't already have it.
-    (`Agent` assumes its transport has this.)
+    Patch abortConnection() on the transport or add it if it doesn't already
+    exist (`Agent` assumes its transport has this).
+
+    The patched method sets an internal flag recording the abort and then calls
+    the original method (if it existed) or transport.loseConnection (if it
+    didn't).
     """
     _old_abortConnection = getattr(
         transport, 'abortConnection', transport.loseConnection)


### PR DESCRIPTION
Twisted 16.1 adds its own abortConnection, so we need to improve our wrapping of abortConnection for fake connections.