### PR TITLE
Vumi Bridge transport can't access Vumi Go over HTTPS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'PyYAML',
         'iso8601',
         'pyOpenSSL',
+        'certifi',
         'service_identity',
         'txssmi>=0.3.0',
         'wokkel',

--- a/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
@@ -37,11 +37,7 @@ class TestGoConversationTransportBase(VumiTestCase):
         transport = yield self.tx_helper.get_transport(defaults, start=False)
         transport.agent_factory = self.fake_http.get_agent
         yield transport.startWorker()
-        yield self.setup_transport(transport)
         returnValue(transport)
-
-    def setup_transport(self, transport):
-        pass
 
     @inlineCallbacks
     def finish_requests(self):

--- a/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
@@ -1,8 +1,11 @@
 import json
+import os
 
 from twisted.internet.defer import inlineCallbacks, returnValue, DeferredQueue
 from twisted.internet.task import Clock
 from twisted.web.server import NOT_DONE_YET
+
+import certifi
 
 from vumi.message import TransportUserMessage
 from vumi.tests.fake_connection import FakeHttpServer
@@ -172,6 +175,11 @@ class TestGoConversationTransport(TestGoConversationTransportBase):
         self.assertEquals(status['component'], 'vumi-go-event')
         self.assertEquals(status['type'], 'bad_request')
         self.assertEquals(status['message'], 'Bad event received from Vumi Go')
+
+    @inlineCallbacks
+    def test_weak_cacerts_installed(self):
+        yield self.get_configured_transport()
+        self.assertEqual(os.environ["SSL_CERT_FILE"], certifi.old_where())
 
     @inlineCallbacks
     def test_sending_messages(self):

--- a/vumi/transports/vumi_bridge/vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/vumi_bridge.py
@@ -2,6 +2,9 @@
 
 import base64
 import json
+import os
+
+import certifi
 
 from twisted.internet.defer import inlineCallbacks
 from twisted.web import http
@@ -198,6 +201,7 @@ class GoConversationTransport(GoConversationTransportBase):
 
     @inlineCallbacks
     def setup_transport(self):
+        self.setup_cacerts()
         config = self.get_static_config()
         self.redis = yield TxRedisManager.from_config(
             config.redis_manager)
@@ -213,6 +217,13 @@ class GoConversationTransport(GoConversationTransportBase):
 
     def teardown_transport(self):
         return self.web_resource.loseConnection()
+
+    def setup_cacerts(self):
+        # TODO: This installs an older CA certificate chain that allows
+        #       some weak CA certificates. We should switch to .where() when
+        #       Vumi Go's certificate doesn't rely on older intermediate
+        #       certificates.
+        os.environ["SSL_CERT_FILE"] = certifi.old_where()
 
     def get_transport_url(self, suffix=''):
         """


### PR DESCRIPTION
Vumi Go's SSL certificate relies on a weak (SHA1) intermediate certificate. This fails to be verified by a lot of server side software (including Twisted) but is accepted by current browsers. Vumi Go's certificate will be updated in October at the latest, but until then the bridge transport needs to accept weaker certificates.