### PR TITLE
Vumi Bridge transport fails to shut down cleanly if it doesn't start up.

### DIFF
--- a/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
@@ -26,7 +26,7 @@ class TestGoConversationTransportBase(VumiTestCase):
         self.add_cleanup(self.finish_requests)
 
     @inlineCallbacks
-    def get_transport(self, **config):
+    def get_transport(self, start=True, **config):
         defaults = {
             'account_key': 'account-key',
             'conversation_key': 'conversation-key',
@@ -36,8 +36,8 @@ class TestGoConversationTransportBase(VumiTestCase):
         defaults.update(config)
         transport = yield self.tx_helper.get_transport(defaults, start=False)
         transport.agent_factory = self.fake_http.get_agent
-        yield transport.startWorker()
-        yield self.setup_transport(transport)
+        if start:
+            yield transport.startWorker()
         returnValue(transport)
 
     def setup_transport(self, transport):
@@ -67,8 +67,8 @@ class TestGoConversationTransport(TestGoConversationTransportBase):
     def test_server_settings_without_configs(self):
         return self.assertFailure(self.get_transport(), ConfigError)
 
-    def get_configured_transport(self):
-        return self.get_transport(web_path='test', web_port='0')
+    def get_configured_transport(self, start=True):
+        return self.get_transport(start=start, web_path='test', web_port='0')
 
     def post_msg(self, url, msg_json):
         data = msg_json.encode('utf-8')
@@ -228,3 +228,8 @@ class TestGoConversationTransport(TestGoConversationTransportBase):
         self.assertEquals(status['type'], 'bad_request')
         self.assertEquals(status['message'],
                           'Message submission rejected by Vumi Go')
+
+    @inlineCallbacks
+    def test_teardown_before_start(self):
+        transport = yield self.get_configured_transport(start=False)
+        yield transport.teardown_transport()

--- a/vumi/transports/vumi_bridge/vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/vumi_bridge.py
@@ -194,6 +194,9 @@ class GoConversationTransport(GoConversationTransportBase):
 
     CONFIG_CLASS = VumiBridgeTransportConfig
 
+    redis = None
+    web_resource = None
+
     @inlineCallbacks
     def setup_transport(self):
         config = self.get_static_config()
@@ -209,8 +212,12 @@ class GoConversationTransport(GoConversationTransportBase):
         ], config.web_port)
         self.status_detect = StatusEdgeDetector()
 
+    @inlineCallbacks
     def teardown_transport(self):
-        return self.web_resource.loseConnection()
+        if self.web_resource is not None:
+            yield self.web_resource.loseConnection()
+        if self.redis is not None:
+            self.redis.close_manager()
 
     def get_transport_url(self, suffix=''):
         """


### PR DESCRIPTION
The teardown method needs to not assume that `.web_resource` is present.