### PR TITLE
Set agent_factory in Vumi Bridge transport.

### DIFF
--- a/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/tests/test_vumi_bridge.py
@@ -3,6 +3,7 @@ import os
 
 from twisted.internet.defer import inlineCallbacks, returnValue, DeferredQueue
 from twisted.internet.task import Clock
+from twisted.web.client import Agent
 from twisted.web.server import NOT_DONE_YET
 
 import certifi
@@ -238,3 +239,6 @@ class TestGoConversationTransport(TestGoConversationTransportBase):
     def test_teardown_before_start(self):
         transport = yield self.get_configured_transport(start=False)
         yield transport.teardown_transport()
+
+    def test_agent_factory_default(self):
+        self.assertEqual(GoConversationTransport.agent_factory, Agent)

--- a/vumi/transports/vumi_bridge/vumi_bridge.py
+++ b/vumi/transports/vumi_bridge/vumi_bridge.py
@@ -10,6 +10,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.web import http
 from twisted.web.resource import Resource
 from twisted.web.server import NOT_DONE_YET
+from twisted.web.client import Agent
 
 from treq.client import HTTPClient
 
@@ -72,7 +73,7 @@ class VumiBridgeTransportConfig(Transport.CONFIG_CLASS):
 
 class GoConversationTransportBase(Transport):
 
-    agent_factory = None  # For swapping out the Agent we use in tests.
+    agent_factory = Agent  # For swapping out the Agent we use in tests.
 
     def get_url(self, path):
         config = self.get_static_config()


### PR DESCRIPTION
Currently the `agent_factory` is not set which means the Vumi Bridge transport is unable to make HTTP requests.