### PR TITLE
Add support for discarding expiry reports to SMPP delivery report processor

### DIFF
--- a/vumi/transports/smpp/config.py
+++ b/vumi/transports/smpp/config.py
@@ -32,6 +32,13 @@ class SmppTransportConfig(Transport.CONFIG_CLASS):
         'causes more noise than signal. It can optionally be turned off. '
         'Defaults to False.',
         default=False, static=True)
+    disable_delivery_report = ConfigBool(
+        'Disable publishing of `delivery_report` events. In some cases this '
+        'event causes more noise than signal. It can optionally be turned '
+        'off. Note that failed or successful delivery reports will still be '
+        'used to track which SMPP message ids can be removed from temporary '
+        'caches. Defaults to False.',
+        default=False, static=True)
     third_party_id_expiry = ConfigInt(
         'How long (in seconds) to keep 3rd party message IDs around to allow '
         'for matching submit_sm_resp and delivery report messages. Defaults '

--- a/vumi/transports/smpp/processors/default.py
+++ b/vumi/transports/smpp/processors/default.py
@@ -102,7 +102,8 @@ class DeliveryReportProcessor(object):
 
         d = self.transport.handle_delivery_report(
             receipted_message_id=receipted_message_id,
-            delivery_status=self.delivery_status(status))
+            delivery_status=self.delivery_status(status),
+            smpp_delivery_status=status)
         d.addCallback(lambda _: True)
         return d
 
@@ -115,7 +116,8 @@ class DeliveryReportProcessor(object):
         message_state = content_fields['stat']
         return self.transport.handle_delivery_report(
             receipted_message_id=receipted_message_id,
-            delivery_status=self.delivery_status(message_state))
+            delivery_status=self.delivery_status(message_state),
+            smpp_delivery_status=message_state)
 
     def _handle_delivery_report_esm_class(self, pdu):
         """

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -492,7 +492,9 @@ class SmppTransceiverTransport(Transport):
         return self.publish_message(**message).addErrback(self.log.err)
 
     @inlineCallbacks
-    def handle_delivery_report(self, receipted_message_id, delivery_status):
+    def handle_delivery_report(
+            self, receipted_message_id, delivery_status,
+            smpp_delivery_status):
         message_id = yield self.message_stash.get_internal_message_id(
             receipted_message_id)
         if message_id is None:
@@ -504,7 +506,10 @@ class SmppTransceiverTransport(Transport):
 
         dr = yield self.publish_delivery_report(
             user_message_id=message_id,
-            delivery_status=delivery_status)
+            delivery_status=delivery_status,
+            transport_metadata={
+                'smpp_delivery_status': smpp_delivery_status,
+            })
 
         if delivery_status in ('delivered', 'failed'):
             yield self.message_stash.expire_remote_message_id(


### PR DESCRIPTION
Sometimes delivery reports go rogue and need to be put out to pasture.