### PR TITLE
Add support for reading to_addr for destination_number to 6D SMPP processor

### DIFF
--- a/vumi/transports/smpp/processors/sixdee.py
+++ b/vumi/transports/smpp/processors/sixdee.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: vumi.transports.smpp.tests.test_sixdee -*-
 
-from vumi.config import ConfigInt
+from vumi.config import ConfigInt, ConfigText
 from vumi.components.session import SessionManager
 from vumi.message import TransportUserMessage
 from vumi.transports.smpp.processors import default
@@ -18,6 +18,11 @@ class DeliverShortMessageProcessorConfig(
     max_session_length = ConfigInt(
         'Maximum length a USSD sessions data is to be kept for in seconds.',
         default=60 * 3, static=True)
+
+    ussd_code_pdu_field = ConfigText(
+        'PDU field to read the message `to_addr` (USSD code) from. Possible'
+        ' options are "short_message" (the default) and "destination_addr".',
+        default='short_message', static=True)
 
 
 class DeliverShortMessageProcessor(default.DeliverShortMessageProcessor):
@@ -63,7 +68,7 @@ class DeliverShortMessageProcessor(default.DeliverShortMessageProcessor):
 
         if session_event == 'new':
             # PSSR request. Let's assume it means a new session.
-            ussd_code = pdu_params['short_message']
+            ussd_code = pdu_params[self.config.ussd_code_pdu_field]
             content = None
 
             yield self.session_manager.create_session(

--- a/vumi/transports/smpp/processors/tests/test_sixdee.py
+++ b/vumi/transports/smpp/processors/tests/test_sixdee.py
@@ -70,8 +70,10 @@ class SixDeeProcessorTestCase(VumiTestCase):
         }
 
     @inlineCallbacks
-    def get_transport(self, config={}, bind=True):
+    def get_transport(self, deliver_config={}, submit_config={}, bind=True):
         cfg = self.default_config.copy()
+        cfg['deliver_short_message_processor_config'].update(deliver_config)
+        cfg['submit_short_message_processor_config'].update(submit_config)
         transport = yield self.tx_helper.get_transport(cfg, start=False)
         transport.clock = self.clock
         yield transport.startWorker()
@@ -128,6 +130,36 @@ class SixDeeProcessorTestCase(VumiTestCase):
 
         # Server delivers a USSD message to the Client
         pdu = DeliverSM(1, short_message="*123#")
+        pdu.add_optional_parameter('ussd_service_op', '01')
+        pdu.add_optional_parameter('its_session_info', session.its_info)
+
+        yield self.fake_smsc.handle_pdu(pdu)
+
+        [mess] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+
+        self.assertEqual(mess['content'], None)
+        self.assertEqual(mess['to_addr'], '*123#')
+        self.assertEqual(mess['transport_type'], "ussd")
+        self.assertEqual(mess['session_event'],
+                         TransportUserMessage.SESSION_NEW)
+        self.assertEqual(
+            mess['transport_metadata'],
+            {
+                'session_info': {
+                    'session_identifier': session.sixdee_id,
+                    'ussd_service_op': '01',
+                }
+            })
+
+    @inlineCallbacks
+    def test_submit_and_deliver_ussd_new_custom_ussd_code_field(self):
+        session = SessionInfo()
+        yield self.get_transport(deliver_config={
+            'ussd_code_pdu_field': 'destination_addr',
+        })
+
+        # Server delivers a USSD message to the Client
+        pdu = DeliverSM(1, short_message="*IGNORE#", destination_addr="*123#")
         pdu.add_optional_parameter('ussd_service_op', '01')
         pdu.add_optional_parameter('its_session_info', session.its_info)
 

--- a/vumi/transports/smpp/processors/tests/test_sixdee.py
+++ b/vumi/transports/smpp/processors/tests/test_sixdee.py
@@ -83,9 +83,15 @@ class SixDeeProcessorTestCase(VumiTestCase):
         returnValue(transport)
 
     def assert_udh_parts(self, pdus, texts, encoding):
-        pdu_header = lambda pdu: short_message(pdu)[:6]
-        pdu_text = lambda pdu: short_message(pdu)[6:].decode(encoding)
-        udh_header = lambda i: '\x05\x00\x03\x03\x07' + chr(i)
+        def pdu_header(pdu):
+            return short_message(pdu)[:6]
+
+        def pdu_text(pdu):
+            return short_message(pdu)[6:].decode(encoding)
+
+        def udh_header(i):
+            return '\x05\x00\x03\x03\x07' + chr(i)
+
         self.assertEqual(
             [(pdu_header(pdu), pdu_text(pdu)) for pdu in pdus],
             [(udh_header(i + 1), text) for i, text in enumerate(texts)])


### PR DESCRIPTION
Currently the 6D SMPP USSD message processor reads the USSD to_addr (i.e. the star code) from the short_message PDU field of the PSSR message. We have encountered some instances that instead sent the to_addr in the destination_number PDU field, and we need a configuration option from reading from that field instead.