### PR TITLE
Fix tests for Twisted 16.3.

### DIFF
--- a/vumi/components/message_store_resource.py
+++ b/vumi/components/message_store_resource.py
@@ -155,7 +155,8 @@ class MessageStoreProxyResource(Resource):
         return d
 
     def write_message(self, message, request):
-        self.formatter.write_row(request, message)
+        if not request.connection_has_been_closed:
+            self.formatter.write_row(request, message)
 
 
 class InboundResource(MessageStoreProxyResource):

--- a/vumi/components/message_store_resource.py
+++ b/vumi/components/message_store_resource.py
@@ -155,7 +155,7 @@ class MessageStoreProxyResource(Resource):
         return d
 
     def write_message(self, message, request):
-        if not request.connection_has_been_closed:
+        if not request.content.closed:
             self.formatter.write_row(request, message)
 
 

--- a/vumi/transports/mxit/tests/test_mxit.py
+++ b/vumi/transports/mxit/tests/test_mxit.py
@@ -2,7 +2,7 @@ import json
 import base64
 
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
-from twisted.web.http import Request, BAD_REQUEST
+from twisted.web.http import BAD_REQUEST
 from twisted.web.server import NOT_DONE_YET
 
 from vumi.transports.mxit import MxitTransport
@@ -10,6 +10,7 @@ from vumi.transports.mxit.responses import ResponseParser
 from vumi.utils import http_request_full
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.fake_connection import FakeHttpServer
+from twisted.web.test.requesthelper import DummyRequest
 from vumi.transports.tests.helpers import TransportHelper
 
 
@@ -62,7 +63,7 @@ class TestMxitTransport(VumiTestCase):
         return NOT_DONE_YET
 
     def test_is_mxit_request(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         self.assertFalse(self.transport.is_mxit_request(req))
         req.requestHeaders.addRawHeader('X-Mxit-Contact', 'foo')
         self.assertTrue(self.transport.is_mxit_request(req))
@@ -100,7 +101,7 @@ class TestMxitTransport(VumiTestCase):
             self.transport.html_decode(self.sample_html_str), '<&>')
 
     def test_get_request_data(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         headers = req.requestHeaders
         for key, value in self.sample_req_headers.items():
             headers.addRawHeader(key, value)
@@ -134,29 +135,29 @@ class TestMxitTransport(VumiTestCase):
         })
 
     def test_get_request_content_from_header(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         req.requestHeaders.addRawHeader('X-Mxit-User-Input', 'foo')
         self.assertEqual(self.transport.get_request_content(req), 'foo')
 
     def test_get_quote_plus_request_content_from_header(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         req.requestHeaders.addRawHeader('X-Mxit-User-Input', 'foo+bar')
         self.assertEqual(
             self.transport.get_request_content(req), 'foo bar')
 
     def test_get_quoted_request_content_from_header(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         req.requestHeaders.addRawHeader('X-Mxit-User-Input', 'foo%20bar')
         self.assertEqual(
             self.transport.get_request_content(req), 'foo bar')
 
     def test_get_request_content_from_args(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         req.args = {'input': ['bar']}
         self.assertEqual(self.transport.get_request_content(req), 'bar')
 
     def test_get_request_content_when_missing(self):
-        req = Request(None, True)
+        req = DummyRequest([])
         self.assertEqual(self.transport.get_request_content(req), None)
 
     @inlineCallbacks

--- a/vumi/transports/mxit/tests/test_mxit.py
+++ b/vumi/transports/mxit/tests/test_mxit.py
@@ -4,14 +4,23 @@ import base64
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
 from twisted.web.http import BAD_REQUEST
 from twisted.web.server import NOT_DONE_YET
+from twisted.web.http_headers import Headers
 
 from vumi.transports.mxit import MxitTransport
 from vumi.transports.mxit.responses import ResponseParser
 from vumi.utils import http_request_full
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.fake_connection import FakeHttpServer
-from twisted.web.test.requesthelper import DummyRequest
+from twisted.web.test.requesthelper import DummyRequest as TwistedDummyRequest
 from vumi.transports.tests.helpers import TransportHelper
+
+
+class DummyRequest(TwistedDummyRequest):
+    def __init__(self, *args, **kw):
+        # Twisted 13.2.0 doesn't have .requestHeaders on DummyRequest
+        TwistedDummyRequest.__init__(self, *args, **kw)
+        if not hasattr(self, 'requestHeaders'):
+            self.requestHeaders = Headers()
 
 
 class TestMxitTransport(VumiTestCase):

--- a/vumi/transports/trueafrican/tests/test_transport.py
+++ b/vumi/transports/trueafrican/tests/test_transport.py
@@ -213,6 +213,7 @@ class TestTrueAfricanUssdTransport(VumiTestCase):
         self.assertEqual(nack['event_type'], 'nack')
         self.assertEqual(nack['user_message_id'], rep['message_id'])
         self.assertEqual(nack['sent_message_id'], rep['message_id'])
+        self.assertTrue('HTTP client closed connection' in nack['nack_reason'])
 
     @inlineCallbacks
     def test_nack_for_request_timeout(self):


### PR DESCRIPTION
Twisted 16.3 changed how HTTPChannels work which broken a bunch of tests:
```
vumi.transports.mxit.tests.test_mxit.TestMxitTransport.test_get_request_content_when_missing
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/home/travis/build/praekelt/vumi/vumi/transports/mxit/tests/test_mxit.py", line 103, in test_get_request_data
    req = Request(None, True)
  File "/home/travis/env-pypy-4.0.1/site-packages/twisted/web/http.py", line 612, in __init__
    self.transport = self.channel.transport
exceptions.AttributeError: 'NoneType' object has no attribute 'transport'
```