### PR TITLE
Only use decimal digits in MTN Nigeria XML over TCP transport session IDs.

### DIFF
--- a/vumi/transports/mtn_nigeria/tests/test_xml_over_tcp.py
+++ b/vumi/transports/mtn_nigeria/tests/test_xml_over_tcp.py
@@ -856,3 +856,9 @@ class TestXmlOverTcpClient(VumiTestCase, XmlOverTcpClientServerMixin):
             'err',
             "Server sent error message: (1337) Unknown Code: "
             "Some Reason")
+
+    def test_gen_session_id(self):
+        sessid = XmlOverTcpClient.gen_session_id()
+        self.assertEqual(len(sessid), XmlOverTcpClient.SESSION_ID_HEADER_SIZE)
+        self.assertTrue(
+            all(c in XmlOverTcpClient.SESSION_ID_CHARACTERS for c in sessid))

--- a/vumi/transports/mtn_nigeria/xml_over_tcp.py
+++ b/vumi/transports/mtn_nigeria/xml_over_tcp.py
@@ -1,6 +1,5 @@
-import uuid
+import random
 import struct
-from random import randint
 
 from twisted.web import microdom
 from twisted.internet import reactor
@@ -58,6 +57,7 @@ class XmlOverTcpClient(Protocol):
     LENGTH_HEADER_SIZE = 16
     HEADER_SIZE = SESSION_ID_HEADER_SIZE + LENGTH_HEADER_SIZE
     HEADER_FORMAT = '!%ss%ss' % (SESSION_ID_HEADER_SIZE, LENGTH_HEADER_SIZE)
+    SESSION_ID_CHARACTERS = "0123456789"
 
     REQUEST_ID_LENGTH = 10
 
@@ -407,17 +407,16 @@ class XmlOverTcpClient(Protocol):
         """
         Generates session id. Used for packets needing a dummy session id.
         """
-        # NOTE: Slicing the generated uuid is probably a bad idea, and will
-        # affect collision resistence, but I can't think of a simpler way to
-        # generate a unique 16 char alphanumeric.
-        return uuid.uuid4().hex[:cls.SESSION_ID_HEADER_SIZE]
+        return "".join(
+            random.choice(cls.SESSION_ID_CHARACTERS)
+            for i in range(cls.SESSION_ID_HEADER_SIZE))
 
     @classmethod
     def gen_request_id(cls):
         # NOTE: The protocol requires request ids to be number only ids. With a
         # request id length of 10 digits, generating ids using randint could
         # well cause collisions to occur, although this should be unlikely.
-        return str(randint(0, (10 ** cls.REQUEST_ID_LENGTH) - 1))
+        return str(random.randint(0, (10 ** cls.REQUEST_ID_LENGTH) - 1))
 
     def login(self):
         params = [


### PR DESCRIPTION
Currently we use hexadecimal digits, but non-decimal digits are not allowed.