### PR TITLE
Dmark transport should set content to null at the start of a USSD session.

### DIFF
--- a/vumi/transports/dmark/dmark_ussd.py
+++ b/vumi/transports/dmark/dmark_ussd.py
@@ -152,12 +152,15 @@ class DmarkUssdTransport(HttpRpcTransport):
 
         to_addr = values["ussdServiceCode"]
         from_addr = values["msisdn"]
+        content = values["ussdRequestString"]
         session_event = yield self.session_event_for_transaction(
             values["transactionId"])
+        if session_event == TransportUserMessage.SESSION_NEW:
+            content = None
 
         yield self.publish_message(
             message_id=request_id,
-            content=values["ussdRequestString"],
+            content=content,
             to_addr=to_addr,
             from_addr=from_addr,
             provider='dmark',

--- a/vumi/transports/dmark/tests/test_dmark_ussd.py
+++ b/vumi/transports/dmark/tests/test_dmark_ussd.py
@@ -89,13 +89,13 @@ class TestDmarkUssdTransport(VumiTestCase):
 
     @inlineCallbacks
     def test_inbound_begin(self):
-        user_content = "Who are you?"
+        user_content = "SHOULD BE IGNORED"
         d = self.tx_helper.mk_request(ussdRequestString=user_content)
         [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
         self.assert_inbound_message(
             msg,
             session_event=TransportUserMessage.SESSION_NEW,
-            content=user_content)
+            content=None)
 
         reply_content = "We are the Knights Who Say ... Ni!"
         reply = msg.reply(reply_content)


### PR DESCRIPTION
Currently it passes through the USSD request string directly from Dmark, which confuses applications because they try to treat it as user input.