### PR TITLE
Cast smpp data coding keys to ints

### DIFF
--- a/vumi/transports/smpp/processors/tests/test_default.py
+++ b/vumi/transports/smpp/processors/tests/test_default.py
@@ -1,4 +1,5 @@
 from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import FailTest
 
 from vumi.errors import ConfigError
 from vumi.tests.helpers import VumiTestCase
@@ -50,10 +51,13 @@ class DefaultProcessorTestCase(VumiTestCase):
                 },
             },
         }
-        with self.assertRaises(ConfigError) as e:
+        try:
             yield self.tx_helper.get_transport(config)
-        self.assertEqual(
-            e.exception.message,
-            "data_coding_overrides keys must be castable to ints. "
-            "invalid literal for int() with base 10: 'not-an-int'"
-        )
+        except ConfigError as e:
+            self.assertEqual(
+                str(e),
+                "data_coding_overrides keys must be castable to ints. "
+                "invalid literal for int() with base 10: 'not-an-int'"
+            )
+        else:
+            raise FailTest("Expected ConfigError to be raised")

--- a/vumi/transports/smpp/processors/tests/test_default.py
+++ b/vumi/transports/smpp/processors/tests/test_default.py
@@ -1,0 +1,59 @@
+from twisted.internet.defer import inlineCallbacks
+
+from vumi.errors import ConfigError
+from vumi.tests.helpers import VumiTestCase
+from vumi.transports.tests.helpers import TransportHelper
+from vumi.transports.smpp.smpp_transport import SmppTransceiverTransport
+from vumi.transports.smpp.tests.fake_smsc import FakeSMSC
+
+
+class DefaultProcessorTestCase(VumiTestCase):
+    def setUp(self):
+        self.fake_smsc = FakeSMSC()
+        self.tx_helper = self.add_helper(
+            TransportHelper(SmppTransceiverTransport))
+
+    @inlineCallbacks
+    def test_data_coding_override_keys_ints(self):
+        """
+        If the keys of the data coding overrides config dictionary are not
+        integers, they should be cast to integers.
+        """
+        config = {
+            'system_id': 'foo',
+            'password': 'bar',
+            'twisted_endpoint': self.fake_smsc.endpoint,
+            'deliver_short_message_processor_config': {
+                'data_coding_overrides': {
+                    '0': 'utf-8'
+                },
+            },
+        }
+        transport = yield self.tx_helper.get_transport(config)
+        self.assertEqual(
+            transport.deliver_sm_processor.data_coding_map.get(0), 'utf-8')
+
+    @inlineCallbacks
+    def test_data_coding_override_keys_invalid(self):
+        """
+        If the keys of the data coding overrides config dictionary can not be
+        cast to integers, a config error with an appropriate message should
+        be raised.
+        """
+        config = {
+            'system_id': 'foo',
+            'password': 'bar',
+            'twisted_endpoint': self.fake_smsc.endpoint,
+            'deliver_short_message_processor_config': {
+                'data_coding_overrides': {
+                    'not-an-int': 'utf-8'
+                },
+            },
+        }
+        with self.assertRaises(ConfigError) as e:
+            yield self.tx_helper.get_transport(config)
+        self.assertEqual(
+            e.exception.message,
+            "data_coding_overrides keys must be castable to ints. "
+            "invalid literal for int() with base 10: 'not-an-int'"
+        )

--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -252,6 +252,8 @@ class SmppTransceiverTransport(Transport):
     bind_type = 'TRX'
     clock = reactor
     start_message_consumer = False
+    service = None
+    redis = None
 
     @property
     def throttled(self):
@@ -293,7 +295,8 @@ class SmppTransceiverTransport(Transport):
     def teardown_transport(self):
         if self.service:
             yield self.service.stopService()
-        yield self.redis._close()
+        if self.redis:
+            yield self.redis._close()
 
     def _check_address_valid(self, message, field):
         try:


### PR DESCRIPTION
This is a reimplementation of https://github.com/praekelt/vumi/pull/1045 , this time with tests.