### PR TITLE
Fix message sender for new riak client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'riak>=2.1',
         'txJSON-RPC==0.3.1',
         'txTwitter>=0.1.4a',
-        'treq',
+        'treq<16.12.0',
         'confmodel>=0.2.0',
         'hyperloglog',
     ],

--- a/vumi/persist/tests/test_riak_manager.py
+++ b/vumi/persist/tests/test_riak_manager.py
@@ -15,13 +15,11 @@ class TestRiakManager(CommonRiakManagerTests, VumiTestCase):
 
     def setUp(self):
         try:
-            from vumi.persist.riak_manager import (
-                RiakManager, flatten_generator)
+            from vumi.persist.riak_manager import flatten_generator
         except ImportError, e:
             import_skip(e, 'riak')
         self.call_decorator = flatten_generator
-        self.manager = RiakManager.from_config({'bucket_prefix': 'test.'})
-        self.add_cleanup(self.manager.purge_all)
+        self.manager = self.create_riak_manager()
         self.manager.purge_all()
 
     def test_call_decorator(self):

--- a/vumi/tests/helpers.py
+++ b/vumi/tests/helpers.py
@@ -1454,7 +1454,12 @@ class PersistenceHelper(object):
                 unclosed_managers.append(manager)
             if purge:
                 try:
-                    yield self._purge_riak(manager)
+                    # Create a new client for cleanup
+                    purge_manager = self.get_riak_manager(config={
+                        'bucket_prefix': manager.bucket_prefix
+                    })
+                    yield self._purge_riak(purge_manager)
+                    yield purge_manager.close_manager()
                 except ConnectionRefusedError:
                     pass
             yield manager.close_manager()


### PR DESCRIPTION
With the new riak client, we will have to change the way that we do cleanup for tests. We need to create a new manager to do the cleanup, instead of using the existing closed manager.