### PR TITLE
Make multipart reference rollover configurable

### DIFF
--- a/vumi/transports/smpp/processors/default.py
+++ b/vumi/transports/smpp/processors/default.py
@@ -470,6 +470,10 @@ class SubmitShortMessageProcessorConfig(Config):
         "If `True`, messages longer than 140 bytes will be sent as a series "
         "of smaller messages with the user data headers. Default is `False`.",
         default=False, static=True)
+    multipart_sar_reference_rollover = ConfigInt(
+        "The maximum value to set for the reference number of a multi part "
+        "SMS. When this value is reached, the number will rollover to 0.",
+        default=0xFFFF, static=True)
 
     def post_validate(self):
         long_message_params = (
@@ -543,6 +547,8 @@ class SubmitShortMessageProcessor(object):
             return service.submit_sm_long(**kwargs)
 
         elif self.config.send_multipart_sar:
+            kwargs['reference_rollover'] = (
+                self.config.multipart_sar_reference_rollover)
             return service.submit_csm_sar(**kwargs)
 
         elif self.config.send_multipart_udh:

--- a/vumi/transports/smpp/processors/default.py
+++ b/vumi/transports/smpp/processors/default.py
@@ -471,9 +471,9 @@ class SubmitShortMessageProcessorConfig(Config):
         "of smaller messages with the user data headers. Default is `False`.",
         default=False, static=True)
     multipart_sar_reference_rollover = ConfigInt(
-        "The maximum value to set for the reference number of a multi part "
-        "SMS. When this value is reached, the number will rollover to 0.",
-        default=0xFFFF, static=True)
+        "The value at which the reference number of a multi part SMS will "
+        "roll over. eg. a value of 2 will result in a series 0, 1, 0, 1 ...",
+        default=0x10000, static=True)
 
     def post_validate(self):
         long_message_params = (

--- a/vumi/transports/smpp/smpp_service.py
+++ b/vumi/transports/smpp/smpp_service.py
@@ -312,7 +312,9 @@ class SmppService(ReconnectingClientService):
         return split_msg
 
     @inlineCallbacks
-    def submit_csm_sar(self, vumi_message_id, destination_addr, **pdu_params):
+    def submit_csm_sar(
+            self, vumi_message_id, destination_addr, reference_rollover=0xFFFF,
+            **pdu_params):
         """
         Submit a concatenated SMS to the SMSC using the optional
         SAR parameter names in the various PDUS.
@@ -339,7 +341,7 @@ class SmppService(ReconnectingClientService):
             pdu_params = pdu_params.copy()
             optional_parameters.update({
                 # Reference number must be between 00 & FFFF
-                'sar_msg_ref_num': (ref_num % 0xFFFF),
+                'sar_msg_ref_num': (ref_num & reference_rollover),
                 'sar_total_segments': len(split_msg),
                 'sar_segment_seqnum': i + 1,
             })

--- a/vumi/transports/smpp/smpp_service.py
+++ b/vumi/transports/smpp/smpp_service.py
@@ -313,8 +313,8 @@ class SmppService(ReconnectingClientService):
 
     @inlineCallbacks
     def submit_csm_sar(
-            self, vumi_message_id, destination_addr, reference_rollover=0xFFFF,
-            **pdu_params):
+            self, vumi_message_id, destination_addr,
+            reference_rollover=0x10000, **pdu_params):
         """
         Submit a concatenated SMS to the SMSC using the optional
         SAR parameter names in the various PDUS.
@@ -340,8 +340,8 @@ class SmppService(ReconnectingClientService):
         for i, msg in enumerate(split_msg):
             pdu_params = pdu_params.copy()
             optional_parameters.update({
-                # Reference number must be between 00 & FFFF
-                'sar_msg_ref_num': (ref_num & reference_rollover),
+                # Reference number must be between 00 & the configure value
+                'sar_msg_ref_num': (ref_num % reference_rollover),
                 'sar_total_segments': len(split_msg),
                 'sar_segment_seqnum': i + 1,
             })

--- a/vumi/transports/smpp/tests/test_smpp_service.py
+++ b/vumi/transports/smpp/tests/test_smpp_service.py
@@ -354,7 +354,7 @@ class TestSmppService(VumiTestCase):
         long_message = 'This is a long message.' * 20
         seq_nums = yield service.submit_csm_sar(
             'abc123', 'dest_addr', short_message=long_message,
-            reference_rollover=0xFF)
+            reference_rollover=0x100)
         pdus = yield self.fake_smsc.await_pdus(4)
         msg_parts = []
         msg_refs = []

--- a/vumi/transports/smpp/tests/test_smpp_service.py
+++ b/vumi/transports/smpp/tests/test_smpp_service.py
@@ -335,7 +335,43 @@ class TestSmppService(VumiTestCase):
             self.assertEqual(4, pdu_opts['sar_total_segments'])
 
         self.assertEqual(long_message, ''.join(msg_parts))
-        self.assertEqual([2, 2, 2, 2], msg_refs)
+        self.assertEqual([1, 1, 1, 1], msg_refs)
+
+        stored_ids = yield self.lookup_message_ids(service, seq_nums)
+        self.assertEqual(['abc123'] * len(seq_nums), stored_ids)
+
+    @inlineCallbacks
+    def test_submit_csm_sar_ref_num_custom_limit(self):
+        """
+        The SAR reference number is set correctly when the generated reference
+        number is larger than the configured limit.
+        """
+        service = yield self.get_service({'send_multipart_sar': True})
+        yield self.fake_smsc.bind()
+        # forward until we go past 0xFF
+        yield self.set_sequence_number(service, 0x100)
+
+        long_message = 'This is a long message.' * 20
+        seq_nums = yield service.submit_csm_sar(
+            'abc123', 'dest_addr', short_message=long_message,
+            reference_rollover=0xFF)
+        pdus = yield self.fake_smsc.await_pdus(4)
+        msg_parts = []
+        msg_refs = []
+
+        for i, sm in enumerate(pdus):
+            pdu_opts = unpacked_pdu_opts(sm)
+            mandatory_parameters = sm['body']['mandatory_parameters']
+
+            self.assertEqual('submit_sm', sm['header']['command_id'])
+            msg_parts.append(mandatory_parameters['short_message'])
+            self.assertTrue(len(mandatory_parameters['short_message']) <= 130)
+            msg_refs.append(pdu_opts['sar_msg_ref_num'])
+            self.assertEqual(i + 1, pdu_opts['sar_segment_seqnum'])
+            self.assertEqual(4, pdu_opts['sar_total_segments'])
+
+        self.assertEqual(long_message, ''.join(msg_parts))
+        self.assertEqual([1, 1, 1, 1], msg_refs)
 
         stored_ids = yield self.lookup_message_ids(service, seq_nums)
         self.assertEqual(['abc123'] * len(seq_nums), stored_ids)


### PR DESCRIPTION
Currently, we rollover the `sar_msg_ref_num` at `0xFFFF`. We want to make this value configurable, for cases where, for example, AAT want us to roll it over at `0xFF` to not affect character space.