### PR TITLE
Add session_id to helper_metadata for dmark

### DIFF
--- a/vumi/transports/dmark/dmark_ussd.py
+++ b/vumi/transports/dmark/dmark_ussd.py
@@ -175,6 +175,9 @@ class DmarkUssdTransport(HttpRpcTransport):
             provider='dmark',
             session_event=session_event,
             transport_type=self.transport_type,
+            helper_metadata={
+                'session_id': values['transactionId'],
+            },
             transport_metadata={
                 'dmark_ussd': {
                     'transaction_id': values['transactionId'],

--- a/vumi/transports/dmark/tests/test_dmark_ussd.py
+++ b/vumi/transports/dmark/tests/test_dmark_ussd.py
@@ -41,6 +41,9 @@ class DmarkTestMixin(object):
             'to_addr': self._to_addr,
             'from_addr': self._from_addr,
             'session_event': TransportUserMessage.SESSION_NEW,
+            'helper_metadata': {
+                'session_id': self._request_defaults['transactionId'],
+            },
             'transport_metadata': {
                 'dmark_ussd': {
                     'transaction_id':


### PR DESCRIPTION
Some external systems, like RapidPro, rely on the channels to provide a 
reliable session identifier. For DMark we'll be relaying whatever transaction
id the aggregator gives us.