### PR TITLE
Add missing publish status method & remove SSLv3 Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'txAMQP>=0.6.2',
         'PyYAML',
         'iso8601',
-        'pyOpenSSL==17.1.0',
+        'pyOpenSSL>= 16.0.0',
         'certifi',
         'service_identity',
         'txssmi>=0.3.0',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'txAMQP>=0.6.2',
         'PyYAML',
         'iso8601',
-        'pyOpenSSL>= 16.0.0',
+        'pyOpenSSL==17.1.0',
         'certifi',
         'service_identity',
         'txssmi>=0.3.0',

--- a/vumi/application/sandbox.py
+++ b/vumi/application/sandbox.py
@@ -26,7 +26,7 @@ from twisted.web.client import WebClientContextFactory, Agent
 
 from OpenSSL.SSL import (
     VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_CLIENT_ONCE, VERIFY_NONE,
-    SSLv3_METHOD, SSLv23_METHOD, TLSv1_METHOD)
+    SSLv23_METHOD, TLSv1_METHOD)
 
 from vumi.config import ConfigText, ConfigInt, ConfigList, ConfigDict
 from vumi.application.base import ApplicationWorker
@@ -883,7 +883,6 @@ class HttpClientResource(SandboxResource):
             'VERIFY_FAIL_IF_NO_PEER_CERT': VERIFY_FAIL_IF_NO_PEER_CERT,
         }
         method_map = {
-            'SSLv3': SSLv3_METHOD,
             'SSLv23': SSLv23_METHOD,
             'TLSv1': TLSv1_METHOD,
         }

--- a/vumi/application/tests/test_sandbox.py
+++ b/vumi/application/tests/test_sandbox.py
@@ -12,8 +12,8 @@ from datetime import datetime
 import warnings
 
 from OpenSSL.SSL import (
-    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_NONE,
-    SSLv3_METHOD, SSLv23_METHOD, TLSv1_METHOD)
+    VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT, VERIFY_NONE, SSLv23_METHOD,
+    TLSv1_METHOD)
 
 from twisted.internet.defer import (
     inlineCallbacks, fail, succeed, DeferredQueue)
@@ -1097,15 +1097,6 @@ class TestHttpClientResource(ResourceTestCaseBase):
         self.assertEqual(
             self.get_context(context_factory).get_verify_mode(), VERIFY_NONE)
 
-    def test_make_context_factory_sslv3_verify_none(self):
-        context_factory = make_context_factory(
-            verify_options=VERIFY_NONE, ssl_method=SSLv3_METHOD)
-        self.assertIsInstance(context_factory, HttpClientContextFactory)
-        self.assertEqual(context_factory.verify_options, VERIFY_NONE)
-        self.assertEqual(context_factory.ssl_method, SSLv3_METHOD)
-        self.assertEqual(
-            self.get_context(context_factory).get_verify_mode(), VERIFY_NONE)
-
     def test_make_context_factory_no_method_verify_peer(self):
         # This test's behaviour depends on the version of Twisted being used.
         context_factory = make_context_factory(verify_options=VERIFY_PEER)
@@ -1143,17 +1134,6 @@ class TestHttpClientResource(ResourceTestCaseBase):
         # This test's behaviour depends on the version of Twisted being used.
         context_factory = make_context_factory()
         self.assertEqual(context_factory.ssl_method, None)
-        if HttpClientPolicyForHTTPS is None:
-            # We have Twisted<14.0.0
-            self.assertIsInstance(context_factory, HttpClientContextFactory)
-            self.assertEqual(context_factory.verify_options, None)
-        else:
-            self.assertIsInstance(context_factory, HttpClientPolicyForHTTPS)
-
-    def test_make_context_factory_sslv3_no_verify(self):
-        # This test's behaviour depends on the version of Twisted being used.
-        context_factory = make_context_factory(ssl_method=SSLv3_METHOD)
-        self.assertEqual(context_factory.ssl_method, SSLv3_METHOD)
         if HttpClientPolicyForHTTPS is None:
             # We have Twisted<14.0.0
             self.assertIsInstance(context_factory, HttpClientContextFactory)
@@ -1336,18 +1316,6 @@ class TestHttpClientResource(ResourceTestCaseBase):
 
         context_factory = self.get_context_factory()
         self.assertEqual(context_factory.ssl_method, None)
-
-    @inlineCallbacks
-    def test_https_request_method_SSLv3(self):
-        self.http_request_succeed("foo")
-        reply = yield self.dispatch_command(
-            'get', url='https://www.example.com', ssl_method='SSLv3')
-        self.assertTrue(reply['success'])
-        self.assertEqual(reply['body'], "foo")
-        self.assert_http_request('https://www.example.com', method='GET')
-
-        context_factory = self.get_context_factory()
-        self.assertEqual(context_factory.ssl_method, SSLv3_METHOD)
 
     @inlineCallbacks
     def test_https_request_method_SSLv23(self):

--- a/vumi/middleware/base.py
+++ b/vumi/middleware/base.py
@@ -171,6 +171,11 @@ class BaseMiddleware(object):
         """
         return failure
 
+    def handle_publish_status(self, status, connector_name):
+        """Called when a status is published.
+        """
+        return status
+
 
 class TransportMiddleware(BaseMiddleware):
     """Message processor middleware for Transports.


### PR DESCRIPTION
This is to resolve the error when enabling the `LoggingMiddleware`.

`AttributeError: 'LoggingMiddleware' object has no attribute 'handle_publish_status'`